### PR TITLE
85 insureduninsured renames (PART 1 of 2)

### DIFF
--- a/contracts/insured-vesting-v1/InsuredVestingV1.sol
+++ b/contracts/insured-vesting-v1/InsuredVestingV1.sol
@@ -8,53 +8,52 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 contract InsuredVestingV1 is Ownable {
     using SafeERC20 for IERC20;
 
-    // TODO(Audit) comment - rename "PROJECT_TOKEN" (FUNDING_TOKEN for insured)
-    IERC20 public immutable USDC;
-    IERC20 public immutable XCTD;
-    uint256 public immutable USDC_TO_XCTD_RATE; // TODO(audit) rename to PROJECT_TOKEN_TO_FUNDING_TOKEN_RATE
+    IERC20 public immutable FUNDING_TOKEN;
+    IERC20 public immutable PROJECT_TOKEN;
+    uint256 public immutable FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE;
     uint256 public immutable VESTING_DURATION_SECONDS;
 
     bool public emergencyReleased = false;
-    address public project;
+    address public projectWallet;
 
-    uint256 public startTime;
-    uint256 public totalUsdcFunded;
+    uint256 public vestingStartTime;
+    uint256 public totalFundingTokenFunded;
 
     enum ClaimDecision {
-        TOKENS,
-        USDC
+        PROJECT_TOKEN,
+        FUNDING_TOKEN
     }
 
     struct UserVesting {
-        // Actual USDC amount funded by user
-        uint256 usdcFunded;
+        // Actual FUNDING_TOKEN amount funded by user
+        uint256 fundingTokenFunded;
         // Investment allocation, set by owner
-        uint256 usdcAllocation;
-        // Whether the user wants to claim XCTD or claim back USDC
+        uint256 fundingTokenAllocation;
+        // Whether the user wants to claim PROJECT_TOKEN or claim back FUNDING_TOKEN
         ClaimDecision claimDecision;
-        // Amount of USDC claimed by user (XCTD is computed from that)
-        uint256 usdcClaimed;
+        // Amount of FUNDING_TOKEN claimed by user (PROJECT_TOKEN is computed from that)
+        uint256 fundingTokenClaimed;
     }
 
     mapping(address => UserVesting) public userVestings;
 
     // --- Events ---
-    event UserClaimed(address indexed target, uint256 usdcAmount, uint256 xctdAmount);
-    event UserEmergencyClaimed(address indexed target, uint256 usdcAmount);
-    event ProjectClaimed(address indexed target, uint256 usdcAmount, uint256 xctdAmount);
-    event AllocationSet(address indexed target, uint256 amount);
+    event UserClaimed(address indexed target, uint256 fundingTokenAmount, uint256 projectTokenAmount);
+    event UserEmergencyClaimed(address indexed target, uint256 fundingTokenAmount);
+    event ProjectClaimed(address indexed target, uint256 fundingTokenAmount, uint256 projectTokenAmount);
+    event AllowedAllocationSet(address indexed target, uint256 amount);
     event FundsAdded(address indexed target, uint256 amount);
     event EmergencyRelease();
     event DecisionChanged(address indexed target, ClaimDecision decision);
     event AmountRecovered(address indexed token, uint256 tokenAmount, uint256 etherAmount);
-    event ProjectAddressChanged(address indexed oldAddress, address indexed newAddress);
-    event VestingStarted(uint256 xctdTransferredToContract);
+    event ProjectWalletAddressChanged(address indexed oldAddress, address indexed newAddress);
+    event VestingStarted(uint256 projectTokenTransferredToContract);
 
     // --- Errors ---
     error ZeroAddress();
     error VestingAlreadyStarted();
     error VestingNotStarted();
-    error AllocationExceeded(uint256 amount);
+    error AllowedAllocationExceeded(uint256 amount);
     error NothingToClaim();
     error NoFundsAdded();
     error EmergencyReleased();
@@ -62,8 +61,8 @@ contract InsuredVestingV1 is Ownable {
     error OnlyOwnerOrSender();
 
     // --- Modifiers ---
-    modifier onlyBeforeVesting() {
-        if (startTime != 0) revert VestingAlreadyStarted();
+    modifier onlyBeforeActivation() {
+        if (vestingStartTime != 0) revert VestingAlreadyStarted();
         _;
     }
 
@@ -77,15 +76,19 @@ contract InsuredVestingV1 is Ownable {
         _;
     }
 
-    constructor(address _usdc, address _xctd, address _project, uint256 _usdcToXctdRate, uint256 _vestingDurationSeconds) {
-        USDC = IERC20(_usdc);
-        XCTD = IERC20(_xctd);
-
-        if (_project == address(0)) revert ZeroAddress(); // TODO(audit) - remove
+    constructor(
+        address _fundingToken,
+        address _projectToken,
+        address _projectWallet,
+        uint256 _fundingTokenToProjectTokenRate,
+        uint256 _vestingDurationSeconds
+    ) {
+        FUNDING_TOKEN = IERC20(_fundingToken);
+        PROJECT_TOKEN = IERC20(_projectToken);
 
         VESTING_DURATION_SECONDS = _vestingDurationSeconds;
         // how many Project tokens you get per each 1 Funding token
-        USDC_TO_XCTD_RATE = _usdcToXctdRate; // 7 XCTD per 1 USD -> 1e12 * 7
+        FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE = _fundingTokenToProjectTokenRate; // 7 PROJECT_TOKEN per 1 USD -> 1e12 * 7
 
         /*
             TODO(audit) - use precision 1e18
@@ -95,48 +98,48 @@ contract InsuredVestingV1 is Ownable {
             RATE = 14_000_000
             (1e18 and 1e6)
 
-            14 cents per XCTD
+            14 cents per PROJECT_TOKEN
          */
 
-        project = _project; // TODO(audit) - rename to projectWallet
+        projectWallet = _projectWallet;
     }
 
     // --- User functions ---
-    function addFunds(uint256 amount) external onlyBeforeVesting onlyIfNotEmergencyReleased {
-        if ((userVestings[msg.sender].usdcAllocation - userVestings[msg.sender].usdcFunded) < amount) revert AllocationExceeded(amount);
+    function addFunds(uint256 amount) external onlyBeforeActivation onlyIfNotEmergencyReleased {
+        if ((userVestings[msg.sender].fundingTokenAllocation - userVestings[msg.sender].fundingTokenFunded) < amount) revert AllowedAllocationExceeded(amount);
 
-        userVestings[msg.sender].usdcFunded += amount;
-        totalUsdcFunded += amount;
-        USDC.safeTransferFrom(msg.sender, address(this), amount);
+        userVestings[msg.sender].fundingTokenFunded += amount;
+        totalFundingTokenFunded += amount;
+        FUNDING_TOKEN.safeTransferFrom(msg.sender, address(this), amount);
 
         emit FundsAdded(msg.sender, amount);
     }
 
     function claim(address target) external onlyOwnerOrSender(target) onlyIfNotEmergencyReleased {
-        if (startTime == 0) revert VestingNotStarted();
+        if (vestingStartTime == 0) revert VestingNotStarted();
 
         UserVesting storage userStatus = userVestings[target];
-        if (userStatus.usdcFunded == 0) revert NoFundsAdded();
+        if (userStatus.fundingTokenFunded == 0) revert NoFundsAdded();
 
-        uint256 claimableUsdc = usdcClaimableFor(target);
-        if (claimableUsdc == 0) revert NothingToClaim();
-        userStatus.usdcClaimed += claimableUsdc;
+        uint256 claimableFundingToken = fundingTokenClaimableFor(target);
+        if (claimableFundingToken == 0) revert NothingToClaim();
+        userStatus.fundingTokenClaimed += claimableFundingToken;
 
-        uint256 claimableXctd = claimableUsdc * USDC_TO_XCTD_RATE;
+        uint256 claimableProjectToken = claimableFundingToken * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE;
 
         // TODO consider using ternary conditions for readability
-        if (userStatus.claimDecision == ClaimDecision.TOKENS) {
-            XCTD.safeTransfer(target, claimableXctd);
-            USDC.safeTransfer(project, claimableUsdc);
+        if (userStatus.claimDecision == ClaimDecision.PROJECT_TOKEN) {
+            PROJECT_TOKEN.safeTransfer(target, claimableProjectToken);
+            FUNDING_TOKEN.safeTransfer(projectWallet, claimableFundingToken);
 
-            emit UserClaimed(target, 0, claimableXctd);
-            emit ProjectClaimed(target, claimableUsdc, 0);
+            emit UserClaimed(target, 0, claimableProjectToken);
+            emit ProjectClaimed(target, claimableFundingToken, 0);
         } else {
-            XCTD.safeTransfer(project, claimableXctd);
-            USDC.safeTransfer(target, claimableUsdc);
+            PROJECT_TOKEN.safeTransfer(projectWallet, claimableProjectToken);
+            FUNDING_TOKEN.safeTransfer(target, claimableFundingToken);
 
-            emit UserClaimed(target, claimableUsdc, 0);
-            emit ProjectClaimed(target, 0, claimableXctd);
+            emit UserClaimed(target, claimableFundingToken, 0);
+            emit ProjectClaimed(target, 0, claimableProjectToken);
         }
     }
 
@@ -144,40 +147,41 @@ contract InsuredVestingV1 is Ownable {
     // decision1 - PROJECT_TOKENS
     // decision2 - REFUND_FUNDING_TOKENS
     function toggleDecision() external {
-        if (userVestings[msg.sender].usdcFunded == 0) revert NoFundsAdded();
-        userVestings[msg.sender].claimDecision = userVestings[msg.sender].claimDecision == ClaimDecision.TOKENS ? ClaimDecision.USDC : ClaimDecision.TOKENS;
+        if (userVestings[msg.sender].fundingTokenFunded == 0) revert NoFundsAdded();
+        userVestings[msg.sender].claimDecision = userVestings[msg.sender].claimDecision == ClaimDecision.PROJECT_TOKEN
+            ? ClaimDecision.FUNDING_TOKEN
+            : ClaimDecision.PROJECT_TOKEN;
 
         emit DecisionChanged(msg.sender, userVestings[msg.sender].claimDecision);
     }
 
     // --- Owner functions ---
 
-    // TODO(audit) - rename to setAllowedAllocation
-    function setAllocation(address target, uint256 _usdcAllocation) external onlyOwner onlyBeforeVesting onlyIfNotEmergencyReleased {
+    function setAllowedAllocation(address target, uint256 _fundingTokenAllocation) external onlyOwner onlyBeforeActivation onlyIfNotEmergencyReleased {
         // Update user allocation
-        userVestings[target].usdcAllocation = _usdcAllocation;
+        userVestings[target].fundingTokenAllocation = _fundingTokenAllocation;
 
         // Refund user if they have funded more than the new allocation
-        if (userVestings[target].usdcFunded > _usdcAllocation) {
-            uint256 _usdcToRefund = userVestings[target].usdcFunded - _usdcAllocation;
-            userVestings[target].usdcFunded = _usdcAllocation;
-            totalUsdcFunded -= _usdcToRefund;
-            USDC.safeTransfer(target, _usdcToRefund);
+        if (userVestings[target].fundingTokenFunded > _fundingTokenAllocation) {
+            uint256 _fundingTokenToRefund = userVestings[target].fundingTokenFunded - _fundingTokenAllocation;
+            userVestings[target].fundingTokenFunded = _fundingTokenAllocation;
+            totalFundingTokenFunded -= _fundingTokenToRefund;
+            FUNDING_TOKEN.safeTransfer(target, _fundingTokenToRefund);
         }
 
-        emit AllocationSet(target, _usdcAllocation);
+        emit AllowedAllocationSet(target, _fundingTokenAllocation);
     }
 
     // TODO(audit) - change similar to VestingV1
-    // TODO(audit) - rename onlyBeforeActivation (consider whether an additional onlyBeforeVestingStarted is needed)
-    function activate() external onlyOwner onlyBeforeVesting {
-        if (totalUsdcFunded == 0) revert NoFundsAdded();
-        startTime = block.timestamp;
+    // TODO(audit) - consider whether an additional onlyBeforeVestingStarted is needed)
+    function activate() external onlyOwner onlyBeforeActivation {
+        if (totalFundingTokenFunded == 0) revert NoFundsAdded();
+        vestingStartTime = block.timestamp;
 
-        uint256 totalRequiredXctd = totalUsdcFunded * USDC_TO_XCTD_RATE;
-        uint256 delta = totalRequiredXctd - Math.min(XCTD.balanceOf(address(this)), totalRequiredXctd);
+        uint256 totalRequiredProjectToken = totalFundingTokenFunded * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE;
+        uint256 delta = totalRequiredProjectToken - Math.min(PROJECT_TOKEN.balanceOf(address(this)), totalRequiredProjectToken);
 
-        XCTD.safeTransferFrom(project, address(this), delta);
+        PROJECT_TOKEN.safeTransferFrom(projectWallet, address(this), delta);
 
         emit VestingStarted(delta);
     }
@@ -186,14 +190,14 @@ contract InsuredVestingV1 is Ownable {
     function setProjectAddress(address newProject) external onlyOwner {
         if (newProject == address(0)) revert ZeroAddress();
 
-        address oldProjectAddress = project;
-        project = newProject;
+        address oldProjectAddress = projectWallet;
+        projectWallet = newProject;
 
-        emit ProjectAddressChanged(oldProjectAddress, newProject);
+        emit ProjectWalletAddressChanged(oldProjectAddress, newProject);
     }
 
     // --- Emergency functions ---
-    // Used to allow users to claim back USDC if anything goes wrong
+    // Used to allow users to claim back FUNDING_TOKEN if anything goes wrong
     function emergencyRelease() external onlyOwner onlyIfNotEmergencyReleased {
         emergencyReleased = true;
         emit EmergencyRelease();
@@ -229,33 +233,33 @@ contract InsuredVestingV1 is Ownable {
     function emergencyClaim(address target) external onlyOwnerOrSender(target) {
         UserVesting storage userStatus = userVestings[target];
         if (!emergencyReleased) revert EmergencyNotReleased();
-        if (userStatus.usdcFunded == 0) revert NoFundsAdded();
+        if (userStatus.fundingTokenFunded == 0) revert NoFundsAdded();
 
-        uint256 toClaim = userStatus.usdcFunded - userStatus.usdcClaimed;
-        userStatus.usdcClaimed += toClaim;
-        USDC.safeTransfer(target, toClaim);
+        uint256 toClaim = userStatus.fundingTokenFunded - userStatus.fundingTokenClaimed;
+        userStatus.fundingTokenClaimed += toClaim;
+        FUNDING_TOKEN.safeTransfer(target, toClaim);
 
         emit UserEmergencyClaimed(target, toClaim);
     }
 
     // TODO(audit) - separate to recoverEth as in VestingV1
     function recover(address tokenAddress) external onlyOwner {
-        // Return any balance of the token that's not xctd
+        // Return any balance of the token that's not projectToken
         uint256 tokenBalanceToRecover = IERC20(tokenAddress).balanceOf(address(this));
-        // // in case of XCTD, we also need to retain the total locked amount in the contract
+        // // in case of PROJECT_TOKEN, we also need to retain the total locked amount in the contract
 
-        if (tokenAddress == address(XCTD) && !emergencyReleased) {
-            tokenBalanceToRecover -= Math.min(totalUsdcFunded * USDC_TO_XCTD_RATE, tokenBalanceToRecover);
+        if (tokenAddress == address(PROJECT_TOKEN) && !emergencyReleased) {
+            tokenBalanceToRecover -= Math.min(totalFundingTokenFunded * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE, tokenBalanceToRecover);
         }
 
-        if (tokenAddress == address(USDC)) {
-            tokenBalanceToRecover -= Math.min(totalUsdcFunded, tokenBalanceToRecover);
+        if (tokenAddress == address(FUNDING_TOKEN)) {
+            tokenBalanceToRecover -= Math.min(totalFundingTokenFunded, tokenBalanceToRecover);
         }
 
-        IERC20(tokenAddress).safeTransfer(project, tokenBalanceToRecover);
+        IERC20(tokenAddress).safeTransfer(projectWallet, tokenBalanceToRecover);
 
         uint256 etherToRecover = address(this).balance;
-        Address.sendValue(payable(project), etherToRecover);
+        Address.sendValue(payable(projectWallet), etherToRecover);
 
         emit AmountRecovered(tokenAddress, tokenBalanceToRecover, etherToRecover);
     }
@@ -263,14 +267,14 @@ contract InsuredVestingV1 is Ownable {
     // --- View functions ---
     // TODO(audit) - view functions as in VestingV1
 
-    function usdcVestedFor(address target) public view returns (uint256) {
-        if (startTime == 0) return 0;
+    function fundingTokenVestedFor(address target) public view returns (uint256) {
+        if (vestingStartTime == 0) return 0;
 
         UserVesting storage targetStatus = userVestings[target];
-        return Math.min(targetStatus.usdcFunded, ((block.timestamp - startTime) * targetStatus.usdcFunded) / VESTING_DURATION_SECONDS);
+        return Math.min(targetStatus.fundingTokenFunded, ((block.timestamp - vestingStartTime) * targetStatus.fundingTokenFunded) / VESTING_DURATION_SECONDS);
     }
 
-    function usdcClaimableFor(address target) public view returns (uint256) {
-        return usdcVestedFor(target) - userVestings[target].usdcClaimed;
+    function fundingTokenClaimableFor(address target) public view returns (uint256) {
+        return fundingTokenVestedFor(target) - userVestings[target].fundingTokenClaimed;
     }
 }

--- a/contracts/insured-vesting-v1/readme.md
+++ b/contracts/insured-vesting-v1/readme.md
@@ -1,11 +1,11 @@
 ## Insured Vesting (InsuredVestingV1)
 
-1. Owner deploys contract with specified USDC/XCTD ratio
+1. Owner deploys contract with specified FUNDING_TOKEN/PROJECT_TOKEN ratio
 2. Owner can set a starting time (lockup) from which vesting will start
-3. Owner sets a USDC allocation per investor (this acts also as a whitelist)
-4. Investors approve and call addFunds with the desired USDC amount
+3. Owner sets a FUNDING_TOKEN allocation per investor (this acts also as a whitelist)
+4. Investors approve and call addFunds with the desired FUNDING_TOKEN amount
 5. Upon activate() functionality being called, start time is finalised. Funds can no longer be added
-6. Investors can toggle their decision between retrieving XCTD and USDC back
+6. Investors can toggle their decision between retrieving PROJECT_TOKEN and FUNDING_TOKEN back
 7. Tokens vest on a per second basis. Only investor or owner can claim according to the decision set.
-   1. If claiming XCTD, project gets USDC in the process
-   2. If claiming USDC, project gets back XCTD proportional to that vesting period
+   1. If claiming PROJECT_TOKEN, project gets FUNDING_TOKEN in the process
+   2. If claiming FUNDING_TOKEN, project gets back PROJECT_TOKEN proportional to that vesting period

--- a/contracts/uninsured-vesting-v1/UninsuredVestingV1.sol
+++ b/contracts/uninsured-vesting-v1/UninsuredVestingV1.sol
@@ -5,8 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Address, IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
-// TODO(Audit) comment - Rename to VestingV1
-contract UninsuredVestingV1 is Ownable {
+contract VestingV1 is Ownable {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable PROJECT_TOKEN;

--- a/contracts/uninsured-vesting-v1/UninsuredVestingV1.sol
+++ b/contracts/uninsured-vesting-v1/UninsuredVestingV1.sol
@@ -9,11 +9,10 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 contract UninsuredVestingV1 is Ownable {
     using SafeERC20 for IERC20;
 
-    // TODO(Audit) comment - rename "PROJECT_TOKEN" (FUNDING_TOKEN for insured)
-    IERC20 public immutable XCTD;
+    IERC20 public immutable PROJECT_TOKEN;
     uint256 public immutable VESTING_DURATION_SECONDS;
 
-    uint256 public startTime;
+    uint256 public vestingStartTime;
     uint256 public totalAllocated;
 
     struct UserVesting {
@@ -30,7 +29,7 @@ contract UninsuredVestingV1 is Ownable {
     event AmountRecovered(address indexed token, uint256 tokenAmount, uint256 etherAmount);
 
     // --- Errors ---
-    error StartTimeTooSoon(uint256 startTime, uint256 minStartTime);
+    error StartTimeTooSoon(uint256 vestingStartTime, uint256 minStartTime);
     error StartTimeNotInFuture(uint256 newStartTime);
     error VestingNotStarted();
     error VestingAlreadyStarted();
@@ -40,25 +39,25 @@ contract UninsuredVestingV1 is Ownable {
 
     // --- Modifiers ---
     modifier onlyBeforeActivation() {
-        if (startTime != 0) revert VestingAlreadyStarted();
+        if (vestingStartTime != 0) revert VestingAlreadyStarted();
         _;
     }
 
-    constructor(address _xctd, uint256 _vestingDurationSeconds) {
-        XCTD = IERC20(_xctd);
-        VESTING_DURATION_SECONDS = _vestingDurationSeconds;
+    constructor(address projectToken, uint256 vestingDurationSeconds) {
+        PROJECT_TOKEN = IERC20(projectToken);
+        VESTING_DURATION_SECONDS = vestingDurationSeconds;
     }
 
     // --- User functions ---
     function claim(address target) external {
         // TODO ensure that we indeed want to apply this restriction (to enable vaults / auto-compounding)
         if (!(msg.sender == owner() || msg.sender == target)) revert OnlyOwnerOrSender();
-        if (startTime == 0) revert VestingNotStarted();
+        if (vestingStartTime == 0) revert VestingNotStarted();
         uint256 claimable = claimableFor(target);
         if (claimable == 0) revert NothingToClaim();
 
         userVestings[target].totalClaimed += claimable;
-        XCTD.safeTransfer(target, claimable);
+        PROJECT_TOKEN.safeTransfer(target, claimable);
 
         emit Claimed(target, claimable);
     }
@@ -81,16 +80,15 @@ contract UninsuredVestingV1 is Ownable {
     // TODO(Audit) comment - activate should get startTime as a parameter, contract would be locked for further investments
     // there will be 2 points of time (add this explanation to header of contract):
     // - activate - locks further allocations and transfers token to contract
-    // - startTime - vesting starts. TODO(Audit) - rename to vestingStartTime
     // - startTime should be MAX more than 3 months
     function activate() external onlyOwner onlyBeforeActivation {
         if (totalAllocated == 0) revert NoAllocationsAdded();
 
-        startTime = block.timestamp;
-        uint256 delta = totalAllocated - Math.min(XCTD.balanceOf(address(this)), totalAllocated);
-        XCTD.safeTransferFrom(msg.sender, address(this), delta);
+        vestingStartTime = block.timestamp;
+        uint256 delta = totalAllocated - Math.min(PROJECT_TOKEN.balanceOf(address(this)), totalAllocated);
+        PROJECT_TOKEN.safeTransferFrom(msg.sender, address(this), delta);
 
-        emit StartTimeSet(startTime);
+        emit StartTimeSet(vestingStartTime);
     }
 
     // --- Emergency functions ---
@@ -98,11 +96,11 @@ contract UninsuredVestingV1 is Ownable {
 
     // TODO(Audit) separate to recoverEther and recoverTokens
     function recover(address tokenAddress) external onlyOwner {
-        // Return any balance of the token that's not XCTD
+        // Return any balance of the token that's not PROJECT_TOKEN
         uint256 tokenBalanceToRecover = IERC20(tokenAddress).balanceOf(address(this));
 
         // Recover only project tokens that were sent by accident (tokens assigned to investors will NOT be recovered)
-        if (tokenAddress == address(XCTD)) {
+        if (tokenAddress == address(PROJECT_TOKEN)) {
             tokenBalanceToRecover -= Math.min(totalAllocated, tokenBalanceToRecover);
         }
 
@@ -122,9 +120,9 @@ contract UninsuredVestingV1 is Ownable {
 
     function totalVestedFor(address target) public view returns (uint256) {
         // TODO(Audit) fix this to take a startTime that hasn't arrived yet into account
-        if (startTime == 0) return 0;
+        if (vestingStartTime == 0) return 0;
         UserVesting storage targetStatus = userVestings[target];
-        return Math.min(targetStatus.amount, ((block.timestamp - startTime) * targetStatus.amount) / VESTING_DURATION_SECONDS);
+        return Math.min(targetStatus.amount, ((block.timestamp - vestingStartTime) * targetStatus.amount) / VESTING_DURATION_SECONDS);
     }
 
     function claimableFor(address target) public view returns (uint256) {

--- a/contracts/uninsured-vesting-v1/readme.md
+++ b/contracts/uninsured-vesting-v1/readme.md
@@ -5,4 +5,4 @@
 3. Owner transfers vested token to contract
 4. Owner sets token allowance per investor
 5. Upon activate() functionality being called, start time is finalised. Funds can no longer be added
-6. Tokens vest on a per second basis. Investors can claim their proportional XCTD allocation
+6. Tokens vest on a per second basis. Investors can claim their proportional PROJECT_TOKEN allocation

--- a/contracts/uninsured-vesting-v1/readme.md
+++ b/contracts/uninsured-vesting-v1/readme.md
@@ -1,4 +1,4 @@
-## Uninsured Vesting (VestingV1)
+## Vesting (VestingV1)
 
 1. Owner deploys
 2. Owner can set a starting time (lockup) from which vesting will start

--- a/deployment/uninsured-vesting-v1/script.ts
+++ b/deployment/uninsured-vesting-v1/script.ts
@@ -2,12 +2,7 @@ import { ConfigTuple } from "./config";
 import BN from "bignumber.js";
 import { DeployParams } from "@defi.org/web3-candies/dist/hardhat";
 
-export const deployUninsuredVestingV1 = async (
-  deploy: (params: DeployParams) => Promise<string>,
-  config: ConfigTuple,
-  maxFeePerGas: BN,
-  maxPriorityFeePerGas: BN
-) => {
+export const deployVestingV1 = async (deploy: (params: DeployParams) => Promise<string>, config: ConfigTuple, maxFeePerGas: BN, maxPriorityFeePerGas: BN) => {
   // TODO: check real XCTD address
   if (config[0] === "0x0000000000000000000000000000000000000000") {
     throw new Error("XCTD address cannot be zero");
@@ -18,7 +13,7 @@ export const deployUninsuredVestingV1 = async (
   }
 
   await deploy({
-    contractName: "UninsuredVestingV1",
+    contractName: "VestingV1",
     args: config,
     maxFeePerGas: maxFeePerGas,
     maxPriorityFeePerGas: maxPriorityFeePerGas,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,10 +9,10 @@ import _ from "lodash";
 import "hardhat-watcher";
 import "solidity-coverage";
 
-import { deployUninsuredVestingV1, ConfigTuple as UninsuredConfig } from "./deployment/uninsured-vesting-v1";
+import { deployVestingV1, ConfigTuple as UninsuredConfig } from "./deployment/uninsured-vesting-v1";
 import { deployInsuredVestingV1, ConfigTuple as InsuredConfig } from "./deployment/insured-vesting-v1";
 
-type Contract = "Insured" | "Uninsured";
+type Contract = "InsuredVesting" | "Vesting";
 
 task("deploy-contract", "Deploy Excited contract")
   .addParam<Contract>("contract", "Contract name")
@@ -21,13 +21,13 @@ task("deploy-contract", "Deploy Excited contract")
     let config: InsuredConfig | UninsuredConfig;
 
     switch (args.contract) {
-      case "Insured":
+      case "InsuredVesting":
         // TODO: confirm name
         contractName = "InsuredVesting";
         config = require("./deployment/insured-vesting-v1/config").config;
         break;
-      case "Uninsured":
-        contractName = "UninsuredVesting";
+      case "Vesting":
+        contractName = "Vesting";
         config = require("./deployment/uninsured-vesting-v1/config").config;
       default:
         console.error("Invalid contract name");
@@ -57,10 +57,10 @@ task("deploy-contract", "Deploy Excited contract")
       console.log("Deploying...");
 
       switch (args.contract) {
-        case "Insured":
+        case "InsuredVesting":
           await deployInsuredVestingV1(deploy, config as InsuredConfig, max, tip);
-        case "Uninsured":
-          await deployUninsuredVestingV1(deploy, config as UninsuredConfig, max, tip);
+        case "Vesting":
+          await deployVestingV1(deploy, config as UninsuredConfig, max, tip);
       }
     }
   });

--- a/test/insured-vesting-v1/deployment.test.ts
+++ b/test/insured-vesting-v1/deployment.test.ts
@@ -9,7 +9,7 @@ import { deployArtifact } from "@defi.org/web3-candies/dist/hardhat";
 import { MockERC20 } from "../../typechain-hardhat/contracts/test/MockERC20";
 import { InsuredVestingV1 } from "../../typechain-hardhat/contracts/insured-vesting-v1/InsuredVestingV1";
 
-import { setup, VESTING_DURATION_SECONDS } from "./fixture";
+import { setup } from "./fixture";
 import { erc20, bn18, Token, account, bn6, zeroAddress } from "@defi.org/web3-candies";
 
 describe("InsuredVestingV1 deployment config", () => {
@@ -22,9 +22,9 @@ describe("InsuredVestingV1 deployment config", () => {
   describe("InsuredVestingV1 deployment", () => {
     before(async () => {
       deployer = await account(9);
-      xctd = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "XCTD"])).options.address);
+      xctd = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "PROJECT_TOKEN"])).options.address);
 
-      // TODO TEMPORARY: until having production XCTD & project addresses
+      // TODO TEMPORARY: until having production PROJECT_TOKEN & project wallet addresses
       const testConfig = [...config];
       testConfig[1] = xctd.options.address;
       testConfig[2] = await account(4);
@@ -36,9 +36,9 @@ describe("InsuredVestingV1 deployment config", () => {
     describe("InsuredVestingV1 deployment", () => {
       before(async () => {
         deployer = await account(9);
-        xctd = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "XCTD"])).options.address);
+        xctd = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "PROJECT_TOKEN"])).options.address);
 
-        // TODO TEMPORARY: until having production XCTD & project addresses
+        // TODO TEMPORARY: until having production PROJECT_TOKEN & project wallet addresses
         const testConfig = [...config];
         testConfig[1] = xctd.options.address;
         testConfig[2] = await account(4);
@@ -48,39 +48,39 @@ describe("InsuredVestingV1 deployment config", () => {
       });
 
       it("xctd address cannot be zero", async () => {
-        const xctd = await insuredVesting.methods.XCTD().call();
+        const xctd = await insuredVesting.methods.PROJECT_TOKEN().call();
         expect(xctd.toLowerCase()).to.not.match(/^0x0+$/);
       });
 
       it("xctd must have 18 decimals", async () => {
-        const xctd = await insuredVesting.methods.XCTD().call();
-        expect(await erc20("XCTD", xctd).decimals()).to.equal(18);
+        const xctd = await insuredVesting.methods.PROJECT_TOKEN().call();
+        expect(await erc20("PROJECT_TOKEN", xctd).decimals()).to.equal(18);
       });
 
       it("usdc address cannot be zero", async () => {
-        const usdc = await insuredVesting.methods.USDC().call();
+        const usdc = await insuredVesting.methods.FUNDING_TOKEN().call();
         expect(usdc.toLowerCase()).to.not.match(/^0x0+$/);
       });
 
       it("usdc must have 6 decimals", async () => {
-        const usdc = await insuredVesting.methods.USDC().call();
-        expect(await erc20("USDC", usdc).decimals()).to.equal(6);
+        const usdc = await insuredVesting.methods.FUNDING_TOKEN().call();
+        expect(await erc20("FUNDING_TOKEN", usdc).decimals()).to.equal(6);
       });
 
-      it("project address cannot be zero", async () => {
-        const project = await insuredVesting.methods.project().call();
-        expect(project.toLowerCase()).to.not.match(/^0x0+$/);
+      it("project wallet address cannot be zero", async () => {
+        const projectWallet = await insuredVesting.methods.projectWallet().call();
+        expect(projectWallet.toLowerCase()).to.not.match(/^0x0+$/);
       });
 
       // TODO define this amount
-      it.skip("project xctd balance must be over [TODO]", async () => {
-        const project = await insuredVesting.methods.project().call();
-        const xctd = erc20("XCTD", await insuredVesting.methods.XCTD().call());
-        expect(await xctd.methods.balanceOf(project).call()).to.be.bignumber.greaterThan(await xctd.amount(999_999_999));
+      it.skip("project wallet xctd balance must be over [TODO]", async () => {
+        const projectWallet = await insuredVesting.methods.projectWallet().call();
+        const xctd = erc20("PROJECT_TOKEN", await insuredVesting.methods.PROJECT_TOKEN().call());
+        expect(await xctd.methods.balanceOf(projectWallet).call()).to.be.bignumber.greaterThan(await xctd.amount(999_999_999));
       });
 
       it("usdc to xctd rate must be at least 1:1", async () => {
-        const usdcToXctdRate = BN(await insuredVesting.methods.USDC_TO_XCTD_RATE().call());
+        const usdcToXctdRate = BN(await insuredVesting.methods.FUNDING_TOKEN_TO_PROJECT_TOKEN_RATE().call());
         expect(usdcToXctdRate).to.be.bignumber.gte(1e12);
       });
 

--- a/test/insured-vesting-v1/insured-vesting-v1.test.ts
+++ b/test/insured-vesting-v1/insured-vesting-v1.test.ts
@@ -1,18 +1,18 @@
 import { expect } from "chai";
 import BN from "bignumber.js";
 import { SnapshotRestorer, takeSnapshot } from "@nomicfoundation/hardhat-network-helpers";
-import { deployArtifact, expectRevert, setBalance, tag } from "@defi.org/web3-candies/dist/hardhat";
+import { deployArtifact, expectRevert, setBalance } from "@defi.org/web3-candies/dist/hardhat";
 import {
   FUNDING_PER_USER,
   LOCKUP_MONTHS,
-  USDC_TO_XCTD_RATIO,
+  FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO,
   advanceMonths,
   anyUser,
-  project,
+  projectWallet,
   user1,
   insuredVesting,
   withFixture,
-  xctd,
+  projectToken,
   deployer,
   someOtherToken,
   getCurrentTimestamp,
@@ -24,23 +24,23 @@ import {
   VESTING_DURATION_SECONDS,
   DAY,
   VESTING_DURATION_DAYS,
-  transferXctdToVesting,
-  approveXctdToVesting,
+  transferProjectTokenToVesting,
+  approveProjectTokenToVesting,
   addFundingFromUser1,
   addFundingFromUser2,
-  setAllocationForUser1,
-  setAllocationForUser2,
-  XCTD_TOKENS_ON_SALE,
+  setAllowedAllocationForUser1,
+  setAllowedAllocationForUser2,
   Event,
   expectProjectBalanceDelta,
   expectUserBalanceDelta,
   setBalancesForDelta,
   vestedAmount,
   balances,
-  usdc,
-  fundUsdcFromWhale,
+  fundingToken,
+  fundFundingTokenFromWhale,
+  PROJECT_TOKENS_ON_SALE,
 } from "./fixture";
-import { account, bn18, bn6, web3, zeroAddress } from "@defi.org/web3-candies";
+import { web3, zeroAddress } from "@defi.org/web3-candies";
 import { InsuredVestingV1 } from "../../typechain-hardhat/contracts/insured-vesting-v1/InsuredVestingV1";
 import { config } from "../../deployment/insured-vesting-v1/config";
 
@@ -57,9 +57,9 @@ describe("InsuredVestingV1", () => {
     await snap.restore();
   });
 
-  describe("with xctd approved to contract", () => {
+  describe("with PROJECT_TOKEN approved to contract", () => {
     beforeEach(async () => {
-      approveXctdToVesting();
+      approveProjectTokenToVesting();
     });
 
     describe("claim", () => {
@@ -67,19 +67,19 @@ describe("InsuredVestingV1", () => {
 
       for (const days of testCases) {
         it(`can claim tokens proportional to amount of seconds in ${days} days passed`, async () => {
-          await setAllocationForUser1();
+          await setAllowedAllocationForUser1();
           await addFundingFromUser1();
           await insuredVesting.methods.activate().send({ from: deployer });
           await advanceDays(days);
           await insuredVesting.methods.claim(user1).send({ from: user1 });
 
-          await expectUserBalanceDelta("xctd", await vestedAmount(days, "xctd"));
-          await expectUserBalanceDelta("usdc", 0);
+          await expectUserBalanceDelta("projectToken", await vestedAmount(days, "projectToken"));
+          await expectUserBalanceDelta("fundingToken", 0);
         });
       }
 
       it("can claim tokens for vesting period 1, multiple fundings", async () => {
-        await setAllocationForUser1(FUNDING_PER_USER);
+        await setAllowedAllocationForUser1(FUNDING_PER_USER);
         await addFundingFromUser1(FUNDING_PER_USER / 4);
         await advanceMonths(1);
         await addFundingFromUser1(FUNDING_PER_USER / 4);
@@ -92,8 +92,8 @@ describe("InsuredVestingV1", () => {
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(6);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await vestedAmount(6, "xctd"));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", await vestedAmount(6, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", 0);
       });
 
       it("can claim tokens for multiple users, random amounts", async () => {
@@ -101,38 +101,38 @@ describe("InsuredVestingV1", () => {
 
         for (const user of additionalUsers) {
           const amountToAllocate = 10 + Math.round(Math.random() * (FUNDING_PER_USER - 10));
-          await insuredVesting.methods.setAllocation(user, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
+          await insuredVesting.methods.setAllowedAllocation(user, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
           const amountToFund = 10 + Math.round(Math.random() * (amountToAllocate - 10));
-          await insuredVesting.methods.addFunds(await usdc.amount(amountToFund)).send({ from: user });
+          await insuredVesting.methods.addFunds(await fundingToken.amount(amountToFund)).send({ from: user });
           additionalUsersFunding.push(amountToFund);
         }
 
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await setBalancesForDelta();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(30);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await vestedAmount(30, "xctd"));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", await vestedAmount(30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", 0);
 
         for (const [index, user] of additionalUsers.entries()) {
           const funding = additionalUsersFunding[index];
-          expect(await xctd.methods.balanceOf(user).call()).to.be.bignumber.zero;
+          expect(await projectToken.methods.balanceOf(user).call()).to.be.bignumber.zero;
           await insuredVesting.methods.claim(user).send({ from: user });
-          expect(await xctd.methods.balanceOf(user).call()).to.be.bignumber.closeTo(
-            (await xctd.amount(funding))
-              .multipliedBy(USDC_TO_XCTD_RATIO)
+          expect(await projectToken.methods.balanceOf(user).call()).to.be.bignumber.closeTo(
+            (await projectToken.amount(funding))
+              .multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO)
               .multipliedBy(30 * DAY)
               .dividedBy(VESTING_DURATION_SECONDS),
-            await xctd.amount(0.1)
+            await projectToken.amount(0.1)
           );
         }
       });
 
       // TODO figure out a way to send both claims in the same block
       it.skip("cannot claim if there's nothing to claim", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         insuredVesting.methods.claim(user1).send({ from: user1 });
@@ -140,19 +140,19 @@ describe("InsuredVestingV1", () => {
         await expectRevert(() => insuredVesting.methods.claim(user1).send({ from: user1 }), Error.NothingToClaim);
       });
 
-      it("can fund a partial allocation and claim tokens", async () => {
-        await setAllocationForUser1();
+      it("can fund a partial allowed allocation and claim tokens", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1(FUNDING_PER_USER / 3);
         await setBalancesForDelta();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(20);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", (await vestedAmount(20, "xctd")).dividedBy(3));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", (await vestedAmount(20, "projectToken")).dividedBy(3));
+        await expectUserBalanceDelta("fundingToken", 0);
       });
 
-      it("can fund a partial allocation multiple times and claim tokens for vesting period 1", async () => {
-        await setAllocationForUser1();
+      it("can fund a partial allowed allocation multiple times and claim tokens for vesting period 1", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1(FUNDING_PER_USER / 4);
         await advanceMonths(2);
         await addFundingFromUser1(FUNDING_PER_USER / 4);
@@ -161,12 +161,12 @@ describe("InsuredVestingV1", () => {
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(20);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", (await vestedAmount(20, "xctd")).dividedBy(2));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", (await vestedAmount(20, "projectToken")).dividedBy(2));
+        await expectUserBalanceDelta("fundingToken", 0);
       });
 
       it("cannot double-claim tokens for same period of time", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(45);
@@ -175,77 +175,77 @@ describe("InsuredVestingV1", () => {
 
         await setBalancesForDelta();
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", 0);
+        await expectUserBalanceDelta("projectToken", 0);
       });
 
       it("cannot claim tokens before starting period, zero time", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await expectRevert(() => insuredVesting.methods.claim(user1).send({ from: user1 }), Error.VestingNotStarted);
       });
 
       it("cannot claim tokens before starting period, some time has passed", async () => {
         await advanceMonths(LOCKUP_MONTHS / 2);
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await expectRevert(() => insuredVesting.methods.claim(user1).send({ from: user1 }), Error.VestingNotStarted);
       });
 
       it("cannot claim if not funded", async () => {
         await advanceMonths(LOCKUP_MONTHS);
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await expectRevert(async () => insuredVesting.methods.claim(user2).send({ from: user2 }), Error.NoFundsAdded);
       });
 
       it("can claim tokens for the entire vesting period", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await setBalancesForDelta();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_DAYS);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await xctd.amount(FUNDING_PER_USER * USDC_TO_XCTD_RATIO));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", await projectToken.amount(FUNDING_PER_USER * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO));
+        await expectUserBalanceDelta("fundingToken", 0);
       });
 
       it("can claim tokens for entire vesting period, many months passed", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await setBalancesForDelta();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_DAYS * 3);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await xctd.amount(FUNDING_PER_USER * USDC_TO_XCTD_RATIO));
-        await expectUserBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", await projectToken.amount(FUNDING_PER_USER * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO));
+        await expectUserBalanceDelta("fundingToken", 0);
       });
 
       it("project receives funding when claim is made", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await setBalancesForDelta();
         await advanceDays(77);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectProjectBalanceDelta("usdc", await vestedAmount(77, "usdc"));
-        await expectProjectBalanceDelta("xctd", 0);
+        await expectProjectBalanceDelta("fundingToken", await vestedAmount(77, "fundingToken"));
+        await expectProjectBalanceDelta("projectToken", 0);
       });
 
       it("owner can claim on behalf of user", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await setBalancesForDelta();
         await advanceDays(77);
         await insuredVesting.methods.claim(user1).send({ from: deployer });
-        await expectProjectBalanceDelta("usdc", await vestedAmount(77, "usdc"));
-        await expectProjectBalanceDelta("xctd", 0);
+        await expectProjectBalanceDelta("fundingToken", await vestedAmount(77, "fundingToken"));
+        await expectProjectBalanceDelta("projectToken", 0);
       });
 
       it("cannot claim if not user or project", async () => {
         await setBalancesForDelta();
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(77);
@@ -253,20 +253,20 @@ describe("InsuredVestingV1", () => {
       });
 
       it("claim according to updated funding if allocation was updated", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
-        await setAllocationForUser1(FUNDING_PER_USER / 4);
+        await setAllowedAllocationForUser1(FUNDING_PER_USER / 4);
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(77);
         await setBalancesForDelta();
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", (await vestedAmount(77, "xctd")).dividedBy(4));
+        await expectUserBalanceDelta("projectToken", (await vestedAmount(77, "projectToken")).dividedBy(4));
       });
     });
 
     describe("toggle decision", () => {
-      it("can toggle decision and claim usdc back (toggle after vesting)", async () => {
-        await setAllocationForUser1();
+      it("can toggle decision and claim fundingToken back (toggle after vesting)", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
 
         await insuredVesting.methods.activate().send({ from: deployer });
@@ -277,14 +277,14 @@ describe("InsuredVestingV1", () => {
         await insuredVesting.methods.toggleDecision().send({ from: user1 });
         await insuredVesting.methods.claim(user1).send({ from: user1 });
 
-        await expectUserBalanceDelta("xctd", 0);
-        await expectProjectBalanceDelta("xctd", await vestedAmount(30, "xctd"));
-        await expectUserBalanceDelta("usdc", await vestedAmount(30, "usdc"));
-        await expectProjectBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", 0);
+        await expectProjectBalanceDelta("projectToken", await vestedAmount(30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", await vestedAmount(30, "fundingToken"));
+        await expectProjectBalanceDelta("fundingToken", 0);
       });
 
-      it("can toggle decision and claim usdc back (toggle before vesting)", async () => {
-        await setAllocationForUser1();
+      it("can toggle decision and claim fundingToken back (toggle before vesting)", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
 
         await insuredVesting.methods.toggleDecision().send({ from: user1 });
@@ -296,61 +296,61 @@ describe("InsuredVestingV1", () => {
 
         await insuredVesting.methods.claim(user1).send({ from: user1 });
 
-        await expectUserBalanceDelta("xctd", 0);
-        await expectProjectBalanceDelta("xctd", await vestedAmount(30, "xctd"));
-        await expectUserBalanceDelta("usdc", await vestedAmount(30, "usdc"));
-        await expectProjectBalanceDelta("usdc", 0);
+        await expectUserBalanceDelta("projectToken", 0);
+        await expectProjectBalanceDelta("projectToken", await vestedAmount(30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", await vestedAmount(30, "fundingToken"));
+        await expectProjectBalanceDelta("fundingToken", 0);
       });
 
-      it("can claim some tokens, some usdc for entire vesting period, use toggle multiple times", async () => {
-        await setAllocationForUser1();
+      it("can claim some tokens, some fundingToken for entire vesting period, use toggle multiple times", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
 
         // Claim for 11 months
         await insuredVesting.methods.activate().send({ from: deployer });
         await setBalancesForDelta();
-        const currentProjectXctdBalance = balances.project.xctd;
+        const currentProjectTokenBalance = balances.project.projectToken;
 
         await advanceDays(11 * 30);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await vestedAmount(11 * 30, "xctd"));
-        await expectUserBalanceDelta("usdc", 0);
-        await expectProjectBalanceDelta("xctd", 0);
-        await expectProjectBalanceDelta("usdc", await vestedAmount(11 * 30, "usdc"));
+        await expectUserBalanceDelta("projectToken", await vestedAmount(11 * 30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", 0);
+        await expectProjectBalanceDelta("projectToken", 0);
+        await expectProjectBalanceDelta("fundingToken", await vestedAmount(11 * 30, "fundingToken"));
 
-        // Toggle, let 3 months pass and claim USDC (we're at month 14)
+        // Toggle, let 3 months pass and claim FUNDING_TOKEN (we're at month 14)
         await insuredVesting.methods.toggleDecision().send({ from: user1 });
         await advanceDays(3 * 30);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await vestedAmount(11 * 30, "xctd"));
-        await expectUserBalanceDelta("usdc", await vestedAmount(3 * 30, "usdc"));
-        await expectProjectBalanceDelta("xctd", await vestedAmount(3 * 30, "xctd"));
-        await expectProjectBalanceDelta("usdc", await vestedAmount(11 * 30, "usdc"));
+        await expectUserBalanceDelta("projectToken", await vestedAmount(11 * 30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", await vestedAmount(3 * 30, "fundingToken"));
+        await expectProjectBalanceDelta("projectToken", await vestedAmount(3 * 30, "projectToken"));
+        await expectProjectBalanceDelta("fundingToken", await vestedAmount(11 * 30, "fundingToken"));
 
         // Let another 3 months pass, toggle again to token and claim (we're at month 17)
         await advanceDays(3 * 30);
         await insuredVesting.methods.toggleDecision().send({ from: user1 });
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", await vestedAmount(14 * 30, "xctd"));
-        await expectUserBalanceDelta("usdc", await vestedAmount(3 * 30, "usdc"));
-        await expectProjectBalanceDelta("xctd", await vestedAmount(3 * 30, "xctd"));
-        await expectProjectBalanceDelta("usdc", await vestedAmount(14 * 30, "usdc"));
+        await expectUserBalanceDelta("projectToken", await vestedAmount(14 * 30, "projectToken"));
+        await expectUserBalanceDelta("fundingToken", await vestedAmount(3 * 30, "fundingToken"));
+        await expectProjectBalanceDelta("projectToken", await vestedAmount(3 * 30, "projectToken"));
+        await expectProjectBalanceDelta("fundingToken", await vestedAmount(14 * 30, "fundingToken"));
 
-        // Toggle again and claim USDC for remaining periods (we're at month 24 - finished)
+        // Toggle again and claim FUNDING_TOKEN for remaining periods (we're at month 24 - finished)
         await insuredVesting.methods.toggleDecision().send({ from: user1 });
         await advanceDays(220);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
 
         // Update balances and verify no remainders
         await setBalancesForDelta();
-        expect(balances.project.usdc.plus(balances.user1.usdc)).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
-        expect(balances.project.xctd.plus(balances.user1.xctd)).to.be.bignumber.eq(
-          (await xctd.amount(FUNDING_PER_USER)).multipliedBy(USDC_TO_XCTD_RATIO).plus(currentProjectXctdBalance)
+        expect(balances.project.fundingToken.plus(balances.user1.fundingToken)).to.be.bignumber.eq(await fundingToken.amount(FUNDING_PER_USER));
+        expect(balances.project.projectToken.plus(balances.user1.projectToken)).to.be.bignumber.eq(
+          (await projectToken.amount(FUNDING_PER_USER)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO).plus(currentProjectTokenBalance)
         );
       });
 
       it("cannot toggle decision if has not funded", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
 
         await expectRevert(() => insuredVesting.methods.toggleDecision().send({ from: user1 }), Error.NoFundsAdded);
       });
@@ -359,27 +359,27 @@ describe("InsuredVestingV1", () => {
     describe("add funds", () => {
       it("can add funds", async () => {
         await setBalancesForDelta();
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
-        await expectUserBalanceDelta("usdc", (await usdc.amount(FUNDING_PER_USER)).negated());
+        await expectUserBalanceDelta("fundingToken", (await fundingToken.amount(FUNDING_PER_USER)).negated());
       });
 
-      it("can add 1 wei amounts of USDC, fully vested", async () => {
+      it("can add 1 wei amounts of FUNDING_TOKEN, fully vested", async () => {
         await setBalancesForDelta();
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await insuredVesting.methods.addFunds(1).send({ from: user1 });
-        await expectUserBalanceDelta("usdc", -1);
+        await expectUserBalanceDelta("fundingToken", -1);
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_DAYS);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", 1e12 * USDC_TO_XCTD_RATIO, 0);
+        await expectUserBalanceDelta("projectToken", 1e12 * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO, 0);
       });
 
-      it("can add 1 wei amounts of USDC, partially vested", async () => {
+      it("can add 1 wei amounts of FUNDING_TOKEN, partially vested", async () => {
         await setBalancesForDelta();
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await insuredVesting.methods.addFunds(1).send({ from: user1 });
-        await expectUserBalanceDelta("usdc", -1);
+        await expectUserBalanceDelta("fundingToken", -1);
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(30);
 
@@ -387,44 +387,44 @@ describe("InsuredVestingV1", () => {
         await expectRevert(async () => insuredVesting.methods.claim(user1).send({ from: user1 }), Error.NothingToClaim);
       });
 
-      it("can add ~wei amounts of USDC, partially vested", async () => {
+      it("can add ~wei amounts of FUNDING_TOKEN, partially vested", async () => {
         await setBalancesForDelta();
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await insuredVesting.methods.addFunds(100).send({ from: user1 });
-        await expectUserBalanceDelta("usdc", -1);
+        await expectUserBalanceDelta("fundingToken", -1);
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(30);
         await insuredVesting.methods.claim(user1).send({ from: user1 });
-        await expectUserBalanceDelta("xctd", 4 * 1e12 * USDC_TO_XCTD_RATIO, 0);
+        await expectUserBalanceDelta("projectToken", 4 * 1e12 * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO, 0);
       });
 
-      it("user cannot fund if does not have allocation", async () => {
-        const amount = await usdc.amount(FUNDING_PER_USER);
-        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllocationExceeded}(${amount})`);
+      it("user cannot fund if does not have allowed allocation", async () => {
+        const amount = await fundingToken.amount(FUNDING_PER_USER);
+        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllowedAllocationExceeded}(${amount})`);
       });
 
-      it("user cannot add more funds than allocation, two attempts", async () => {
-        await setAllocationForUser1();
+      it("user cannot add more funds than allowed allocation, two attempts", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
-        const amount = await usdc.amount(1);
-        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllocationExceeded}(${amount})`);
+        const amount = await fundingToken.amount(1);
+        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllowedAllocationExceeded}(${amount})`);
       });
 
-      it("user cannot add more funds than allocation, single attempts", async () => {
-        await setAllocationForUser1();
-        const amount = await usdc.amount(FUNDING_PER_USER + 1);
-        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllocationExceeded}(${amount})`);
+      it("user cannot add more funds than allowed allocation, single attempts", async () => {
+        await setAllowedAllocationForUser1();
+        const amount = await fundingToken.amount(FUNDING_PER_USER + 1);
+        await expectRevert(async () => insuredVesting.methods.addFunds(amount).send({ from: user1 }), `${Error.AllowedAllocationExceeded}(${amount})`);
       });
 
       it("cannot add funds after vesting started", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1(FUNDING_PER_USER / 2);
         await insuredVesting.methods.activate().send({ from: deployer });
         await expectRevert(async () => insuredVesting.methods.addFunds(1).send({ from: user1 }), Error.VestingAlreadyStarted);
       });
 
       it("cannot add funds if emergency released", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1(FUNDING_PER_USER / 2);
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await expectRevert(async () => insuredVesting.methods.addFunds(1).send({ from: user1 }), Error.EmergencyReleased);
@@ -432,138 +432,139 @@ describe("InsuredVestingV1", () => {
 
       it("fails if user does not have enough balance", async () => {
         const amount = FUNDING_PER_USER + 1;
-        await insuredVesting.methods.setAllocation(user1, await usdc.amount(amount)).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(amount)).send({ from: deployer });
         await expectRevert(
-          async () => insuredVesting.methods.addFunds(await usdc.amount(amount)).send({ from: user1 }),
+          async () => insuredVesting.methods.addFunds(await fundingToken.amount(amount)).send({ from: user1 }),
           "ERC20: transfer amount exceeds allowance"
         );
       });
     });
 
     describe("admin", () => {
-      describe("set allocation", () => {
-        it("cannot set allocation after period started", async () => {
-          await setAllocationForUser1(FUNDING_PER_USER / 4);
+      describe("set allowed allocation", () => {
+        it("cannot set allowed allocation after period started", async () => {
+          await setAllowedAllocationForUser1(FUNDING_PER_USER / 4);
           await addFundingFromUser1(FUNDING_PER_USER / 4);
           await insuredVesting.methods.activate().send({ from: deployer });
           await expectRevert(
-            async () => insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer }),
+            async () => insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer }),
             Error.VestingAlreadyStarted
           );
         });
 
-        describe("existing excess deposit is refunded in case of allocation decrease", () => {
+        describe("existing excess deposit is refunded in case of allowed allocation decrease", () => {
           it("single user", async () => {
             await setBalancesForDelta();
-            await setAllocationForUser1();
+            await setAllowedAllocationForUser1();
             await addFundingFromUser1();
-            await expectUserBalanceDelta("usdc", (await usdc.amount(FUNDING_PER_USER)).negated(), 1);
+            await expectUserBalanceDelta("fundingToken", (await fundingToken.amount(FUNDING_PER_USER)).negated(), 1);
 
             await setBalancesForDelta();
             const newAmount = FUNDING_PER_USER / 3;
-            const newAllocation = await usdc.amount(newAmount);
-            await insuredVesting.methods.setAllocation(user1, newAllocation).send({ from: deployer });
+            const newAllowedAllocation = await fundingToken.amount(newAmount);
+            await insuredVesting.methods.setAllowedAllocation(user1, newAllowedAllocation).send({ from: deployer });
 
-            // // check user USDC balance reflects refunded amount
-            await expectUserBalanceDelta("usdc", await usdc.amount(FUNDING_PER_USER - newAmount), 1);
-            // // check contract USDC balance has been updated
-            expect(await usdc.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(newAllocation);
+            // // check user FUNDING_TOKEN balance reflects refunded amount
+            await expectUserBalanceDelta("fundingToken", await fundingToken.amount(FUNDING_PER_USER - newAmount), 1);
+            // // check contract FUNDING_TOKEN balance has been updated
+            expect(await fundingToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(newAllowedAllocation);
             // // check user allocation has been updated
-            expect((await insuredVesting.methods.userVestings(user1).call()).usdcAllocation).to.be.bignumber.eq(newAllocation);
+            expect((await insuredVesting.methods.userVestings(user1).call()).fundingTokenAllocation).to.be.bignumber.eq(newAllowedAllocation);
           });
 
           // TODO: multiple user scenarios
         });
 
-        describe("setAllocation", () => {
-          const testCases: { description: string; setAllocationsFn: () => Promise<any>; expectedAllocation: BN }[] = [
+        describe("setAllowedAllocation", () => {
+          const testCases: { description: string; setAllowedAllocationsFn: () => Promise<any>; expectedAllocation: BN }[] = [
             {
               description: "single user",
-              setAllocationsFn: async () => await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer }),
+              setAllowedAllocationsFn: async () =>
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer }),
               expectedAllocation: BN(FUNDING_PER_USER),
             },
             {
               description: "multiple users, smaller allocation added",
-              setAllocationsFn: async () => {
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER / 5)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
+              setAllowedAllocationsFn: async () => {
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER / 5)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
               },
               expectedAllocation: BN(FUNDING_PER_USER / 2),
             },
             {
               description: "multiple users, larger allocation added",
-              setAllocationsFn: async () => {
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
+              setAllowedAllocationsFn: async () => {
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
               },
               expectedAllocation: BN(FUNDING_PER_USER),
             },
             {
               description: "multiple users, allocation removed",
-              setAllocationsFn: async () => {
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(0)).send({ from: deployer });
+              setAllowedAllocationsFn: async () => {
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER / 2)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(0)).send({ from: deployer });
               },
               expectedAllocation: BN(FUNDING_PER_USER),
             },
             {
               description: "allocation increased after funding",
-              setAllocationsFn: async () => {
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-                await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-                await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user1 });
-                await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER * 2)).send({ from: deployer });
+              setAllowedAllocationsFn: async () => {
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+                await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+                await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user1 });
+                await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER * 2)).send({ from: deployer });
               },
               expectedAllocation: BN(FUNDING_PER_USER * 2),
             },
           ];
 
-          testCases.forEach(({ description, setAllocationsFn, expectedAllocation }) => {
+          testCases.forEach(({ description, setAllowedAllocationsFn, expectedAllocation }) => {
             it(description, async () => {
-              await setAllocationsFn();
-              const actualUsdcAllocation = (await insuredVesting.methods.userVestings(user1).call()).usdcAllocation;
-              expect(actualUsdcAllocation).to.be.bignumber.eq(await usdc.amount(expectedAllocation));
+              await setAllowedAllocationsFn();
+              const actualFundingTokenAllocation = (await insuredVesting.methods.userVestings(user1).call()).fundingTokenAllocation;
+              expect(actualFundingTokenAllocation).to.be.bignumber.eq(await fundingToken.amount(expectedAllocation));
             });
           });
         });
       });
 
       it("cannot set allocation if emergency released", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
-        await expectRevert(() => insuredVesting.methods.setAllocation(user1, 1).send({ from: deployer }), Error.EmergencyReleased);
+        await expectRevert(() => insuredVesting.methods.setAllowedAllocation(user1, 1).send({ from: deployer }), Error.EmergencyReleased);
       });
     });
 
     describe("emergency release", () => {
-      it("lets user emergency claim back all USDC balance, no XCTD has been claimed", async () => {
-        await setAllocationForUser1();
+      it("lets user emergency claim back all FUNDING_TOKEN balance, no PROJECT_TOKEN has been claimed", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await insuredVesting.methods.emergencyClaim(user1).send({ from: user1 });
-        expect(await usdc.methods.balanceOf(user1).call()).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
+        expect(await fundingToken.methods.balanceOf(user1).call()).to.be.bignumber.eq(await fundingToken.amount(FUNDING_PER_USER));
       });
 
-      it("lets owner emergency claim back all USDC balance on behalf of user, no XCTD has been claimed", async () => {
-        await setAllocationForUser1();
+      it("lets owner emergency claim back all FUNDING_TOKEN balance on behalf of user, no PROJECT_TOKEN has been claimed", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await insuredVesting.methods.emergencyClaim(user1).send({ from: deployer });
-        expect(await usdc.methods.balanceOf(user1).call()).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
+        expect(await fundingToken.methods.balanceOf(user1).call()).to.be.bignumber.eq(await fundingToken.amount(FUNDING_PER_USER));
       });
 
       it("cannot emergency claim if hasn't funded", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await expectRevert(() => insuredVesting.methods.emergencyClaim(user1).send({ from: user1 }), Error.NoFundsAdded);
       });
 
-      it("lets user emergency claim back remaining USDC balance, some XCTD claimed", async () => {
-        await setAllocationForUser1();
+      it("lets user emergency claim back remaining FUNDING_TOKEN balance, some PROJECT_TOKEN claimed", async () => {
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_DAYS / 10);
@@ -571,11 +572,14 @@ describe("InsuredVestingV1", () => {
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
 
         await insuredVesting.methods.emergencyClaim(user1).send({ from: user1 });
-        expect(await usdc.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(BN((await usdc.amount(FUNDING_PER_USER)).multipliedBy(0.9)), 200);
+        expect(await fundingToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+          BN((await fundingToken.amount(FUNDING_PER_USER)).multipliedBy(0.9)),
+          200
+        );
       });
 
       it("cannot regularly claim once emergency released", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await insuredVesting.methods.activate().send({ from: deployer });
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
@@ -583,34 +587,34 @@ describe("InsuredVestingV1", () => {
       });
 
       it("cannot emergency claim twice", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
-        await setAllocationForUser2();
+        await setAllowedAllocationForUser2();
         await addFundingFromUser2();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await insuredVesting.methods.emergencyClaim(user1).send({ from: user1 });
-        expect(await usdc.methods.balanceOf(user1).call()).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
+        expect(await fundingToken.methods.balanceOf(user1).call()).to.be.bignumber.eq(await fundingToken.amount(FUNDING_PER_USER));
         await insuredVesting.methods.emergencyClaim(user1).send({ from: user1 });
-        expect(await usdc.methods.balanceOf(user1).call()).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
+        expect(await fundingToken.methods.balanceOf(user1).call()).to.be.bignumber.eq(await fundingToken.amount(FUNDING_PER_USER));
       });
 
       it("cannot emergency claim if owner hasn't released", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await expectRevert(() => insuredVesting.methods.emergencyClaim(user1).send({ from: user1 }), Error.EmergencyNotReleased);
       });
 
       it("only owner or user can emergency claim", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
-        await setAllocationForUser2();
+        await setAllowedAllocationForUser2();
         await addFundingFromUser2();
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
         await expectRevert(() => insuredVesting.methods.emergencyClaim(user1).send({ from: user2 }), Error.OnlyOwnerOrSender);
       });
 
       it("only owner can emergency release", async () => {
-        await setAllocationForUser1();
+        await setAllowedAllocationForUser1();
         await addFundingFromUser1();
         await expectRevert(() => insuredVesting.methods.emergencyRelease().send({ from: user1 }), "Ownable: caller is not the owner");
       });
@@ -620,29 +624,29 @@ describe("InsuredVestingV1", () => {
         await expectRevert(() => insuredVesting.methods.emergencyRelease().send({ from: deployer }), Error.EmergencyReleased);
       });
 
-      it("recovers all remaining xctd balance if emergency released", async () => {
-        await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await transferXctdToVesting(FUNDING_PER_USER * 2 * USDC_TO_XCTD_RATIO);
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user1 });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user2 });
+      it("recovers all remaining PROJECT_TOKEN balance if emergency released", async () => {
+        await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await transferProjectTokenToVesting(FUNDING_PER_USER * 2 * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO);
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user1 });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user2 });
         await insuredVesting.methods.emergencyRelease().send({ from: deployer });
 
         await setBalancesForDelta();
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         // Recover all but the tokens allocated to users, backed by funding
-        expect(await xctd.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(0);
-        await expectProjectBalanceDelta("xctd", (await xctd.amount(FUNDING_PER_USER * 2)).multipliedBy(USDC_TO_XCTD_RATIO));
-        await expectProjectBalanceDelta("usdc", 0);
+        expect(await projectToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(0);
+        await expectProjectBalanceDelta("projectToken", (await projectToken.amount(FUNDING_PER_USER * 2)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO));
+        await expectProjectBalanceDelta("fundingToken", 0);
       });
     });
 
-    describe("update project address", () => {
+    describe("update project wallet address", () => {
       it("should only be updatable by owner", async () => {
-        expect(await insuredVesting.methods.project().call()).to.be.eq(project);
-        const newProjectAddress = "0x148A0353F50Ba5683Ab0513CF6bda4E4fD43d7D4";
-        await insuredVesting.methods.setProjectAddress(newProjectAddress).send({ from: deployer });
-        expect(await insuredVesting.methods.project().call()).to.be.eq(newProjectAddress);
+        expect(await insuredVesting.methods.projectWallet().call()).to.be.eq(projectWallet);
+        const newProjectWalletAddress = "0x148A0353F50Ba5683Ab0513CF6bda4E4fD43d7D4";
+        await insuredVesting.methods.setProjectAddress(newProjectWalletAddress).send({ from: deployer });
+        expect(await insuredVesting.methods.projectWallet().call()).to.be.eq(newProjectWalletAddress);
       });
 
       it("should not be updatable by non-owner", async () => {
@@ -654,11 +658,11 @@ describe("InsuredVestingV1", () => {
         await expectRevert(() => insuredVesting.methods.setProjectAddress(zeroAddress).send({ from: deployer }), Error.ZeroAddress);
       });
 
-      it(`should emit '${Event.ProjectAddressChanged}' event upon updating`, async () => {
+      it(`should emit '${Event.ProjectWalletAddressChanged}' event upon updating`, async () => {
         const newProjectAddress = "0x148A0353F50Ba5683Ab0513CF6bda4E4fD43d7D4";
         await insuredVesting.methods.setProjectAddress(newProjectAddress).send({ from: deployer });
-        const events = await insuredVesting.getPastEvents(Event.ProjectAddressChanged);
-        expect(events[0].returnValues.oldAddress).to.be.eq(project);
+        const events = await insuredVesting.getPastEvents(Event.ProjectWalletAddressChanged);
+        expect(events[0].returnValues.oldAddress).to.be.eq(projectWallet);
         expect(events[0].returnValues.newAddress).to.be.eq(newProjectAddress);
       });
     });
@@ -666,12 +670,12 @@ describe("InsuredVestingV1", () => {
     // TODO add expectations for project balances
     describe("recovery", () => {
       it("recovers ether", async () => {
-        const startingBalance = await web3().eth.getBalance(project);
+        const startingBalance = await web3().eth.getBalance(projectWallet);
         expect(await web3().eth.getBalance(insuredVesting.options.address)).to.bignumber.eq(0);
         await setBalance(insuredVesting.options.address, BN(12345 * 1e18));
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         expect(await web3().eth.getBalance(insuredVesting.options.address)).to.be.bignumber.zero;
-        expect(await web3().eth.getBalance(project)).to.bignumber.closeTo(BN(12345 * 1e18).plus(startingBalance), BN(0.1e18));
+        expect(await web3().eth.getBalance(projectWallet)).to.bignumber.closeTo(BN(12345 * 1e18).plus(startingBalance), BN(0.1e18));
       });
 
       it("recovers other tokens", async () => {
@@ -680,65 +684,69 @@ describe("InsuredVestingV1", () => {
         expect(await someOtherToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.zero;
       });
 
-      // TODO does retrieiving XCTD work only based off allocations or do we have the option to cancel before vesting started.
-      it("recovers excess xctd (fully funded) ", async () => {
-        await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await transferXctdToVesting();
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user1 });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user2 });
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+      // TODO does retrieiving PROJECT_TOKEN work only based off allocations or do we have the option to cancel before vesting started.
+      it("recovers excess PROJECT_TOKEN (fully funded) ", async () => {
+        await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await transferProjectTokenToVesting();
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user1 });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user2 });
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         // Recover all but the tokens allocated to users, backed by funding
-        expect(await xctd.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(
-          (await xctd.amount(FUNDING_PER_USER * 2)).multipliedBy(USDC_TO_XCTD_RATIO)
+        expect(await projectToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(
+          (await projectToken.amount(FUNDING_PER_USER * 2)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO)
         );
       });
 
-      it("recovers excess xctd (underfunded)", async () => {
-        await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user1 });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user2 });
-        await xctd.methods.transfer(insuredVesting.options.address, await xctd.amount(100)).send({ from: project });
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+      it("recovers excess PROJECT_TOKEN (underfunded)", async () => {
+        await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user1 });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user2 });
+        await projectToken.methods.transfer(insuredVesting.options.address, await projectToken.amount(100)).send({ from: projectWallet });
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         // Retains tokens in the contract, nothing to recover
-        expect(await xctd.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(100));
+        expect(await projectToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(100));
       });
 
       // TODO refactor balance deltas
       // todo expectbalancedelta shouldn't run token.amount(...)
       it("recovers by zeroing out allocations (pre-activation)", async () => {
-        await insuredVesting.methods.setAllocation(user1, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.setAllocation(user2, await usdc.amount(FUNDING_PER_USER)).send({ from: deployer });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user1 });
-        await insuredVesting.methods.addFunds(await usdc.amount(FUNDING_PER_USER)).send({ from: user2 });
-        await transferXctdToVesting();
+        await insuredVesting.methods.setAllowedAllocation(user1, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user2, await fundingToken.amount(FUNDING_PER_USER)).send({ from: deployer });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user1 });
+        await insuredVesting.methods.addFunds(await fundingToken.amount(FUNDING_PER_USER)).send({ from: user2 });
+        await transferProjectTokenToVesting();
 
-        let initiaProjectBalance = await xctd.methods.balanceOf(project).call();
+        let initiaProjectBalance = await projectToken.methods.balanceOf(projectWallet).call();
         await setBalancesForDelta();
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
 
-        expect(await xctd.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(
-          (await xctd.amount(FUNDING_PER_USER * 2)).multipliedBy(USDC_TO_XCTD_RATIO)
+        expect(await projectToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(
+          (await projectToken.amount(FUNDING_PER_USER * 2)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO)
         );
-        expect(await xctd.methods.balanceOf(project).call()).to.be.bignumber.eq(
+        expect(await projectToken.methods.balanceOf(projectWallet).call()).to.be.bignumber.eq(
           BN(initiaProjectBalance)
-            .plus(await xctd.amount(XCTD_TOKENS_ON_SALE))
-            .minus((await xctd.amount(FUNDING_PER_USER * 2)).multipliedBy(USDC_TO_XCTD_RATIO))
+            .plus(await projectToken.amount(PROJECT_TOKENS_ON_SALE))
+            .minus((await projectToken.amount(FUNDING_PER_USER * 2)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO))
         );
 
-        const user1UsdcBalanceBefore = await usdc.methods.balanceOf(user1).call();
-        const user2UsdcBalanceBefore = await usdc.methods.balanceOf(user2).call();
-        await insuredVesting.methods.setAllocation(user1, 0).send({ from: deployer });
-        await insuredVesting.methods.setAllocation(user2, 0).send({ from: deployer });
-        expect(BN(await usdc.methods.balanceOf(user1).call()).minus(user1UsdcBalanceBefore)).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
-        expect(BN(await usdc.methods.balanceOf(user2).call()).minus(user2UsdcBalanceBefore)).to.be.bignumber.eq(await usdc.amount(FUNDING_PER_USER));
+        const user1FundingTokenBalanceBefore = await fundingToken.methods.balanceOf(user1).call();
+        const user2FundingTokenBalanceBefore = await fundingToken.methods.balanceOf(user2).call();
+        await insuredVesting.methods.setAllowedAllocation(user1, 0).send({ from: deployer });
+        await insuredVesting.methods.setAllowedAllocation(user2, 0).send({ from: deployer });
+        expect(BN(await fundingToken.methods.balanceOf(user1).call()).minus(user1FundingTokenBalanceBefore)).to.be.bignumber.eq(
+          await fundingToken.amount(FUNDING_PER_USER)
+        );
+        expect(BN(await fundingToken.methods.balanceOf(user2).call()).minus(user2FundingTokenBalanceBefore)).to.be.bignumber.eq(
+          await fundingToken.amount(FUNDING_PER_USER)
+        );
 
-        initiaProjectBalance = await xctd.methods.balanceOf(project).call();
-        await insuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        expect(await xctd.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(0);
-        expect(await xctd.methods.balanceOf(project).call()).to.be.bignumber.eq(
-          BN(initiaProjectBalance).plus((await xctd.amount(FUNDING_PER_USER * 2)).multipliedBy(USDC_TO_XCTD_RATIO))
+        initiaProjectBalance = await projectToken.methods.balanceOf(projectWallet).call();
+        await insuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(insuredVesting.options.address).call()).to.be.bignumber.eq(0);
+        expect(await projectToken.methods.balanceOf(projectWallet).call()).to.be.bignumber.eq(
+          BN(initiaProjectBalance).plus((await projectToken.amount(FUNDING_PER_USER * 2)).multipliedBy(FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO))
         );
       });
 
@@ -747,29 +755,32 @@ describe("InsuredVestingV1", () => {
         ["overfunded", FUNDING_PER_USER * 3],
         ["exactly funded", 0],
       ].forEach(([scenario, extraFundingToPass]) => {
-        it(`does not recover funded usdc (${scenario})`, async () => {
-          await setAllocationForUser1();
-          await setAllocationForUser2();
+        it(`does not recover funded fundingToken (${scenario})`, async () => {
+          await setAllowedAllocationForUser1();
+          await setAllowedAllocationForUser2();
           await addFundingFromUser1();
           await addFundingFromUser2();
 
-          await fundUsdcFromWhale(BN(extraFundingToPass), [insuredVesting.options.address]);
+          await fundFundingTokenFromWhale(BN(extraFundingToPass), [insuredVesting.options.address]);
 
           await setBalancesForDelta();
-          await insuredVesting.methods.recover(usdc.options.address).send({ from: deployer });
-          await expectProjectBalanceDelta("xctd", 0);
-          await expectProjectBalanceDelta("usdc", await usdc.amount(extraFundingToPass));
+          await insuredVesting.methods.recover(fundingToken.options.address).send({ from: deployer });
+          await expectProjectBalanceDelta("projectToken", 0);
+          await expectProjectBalanceDelta("fundingToken", await fundingToken.amount(extraFundingToPass));
         });
       });
     });
 
     describe("access control", () => {
-      it("cannot add allocations if not owner", async () => {
-        await expectRevert(async () => insuredVesting.methods.setAllocation(user1, 1).send({ from: anyUser }), "Ownable: caller is not the owner");
+      it("cannot add allowed allocations if not owner", async () => {
+        await expectRevert(async () => insuredVesting.methods.setAllowedAllocation(user1, 1).send({ from: anyUser }), "Ownable: caller is not the owner");
       });
 
       it("cannot recover if not owner", async () => {
-        await expectRevert(async () => insuredVesting.methods.recover(xctd.options.address).send({ from: anyUser }), "Ownable: caller is not the owner");
+        await expectRevert(
+          async () => insuredVesting.methods.recover(projectToken.options.address).send({ from: anyUser }),
+          "Ownable: caller is not the owner"
+        );
       });
 
       it("cannot trigger emergency release if not owner", async () => {
@@ -779,95 +790,95 @@ describe("InsuredVestingV1", () => {
 
     describe("view functions", () => {
       it("returns 0 vested when not activated", async () => {
-        await setAllocationForUser1(FUNDING_PER_USER);
+        await setAllowedAllocationForUser1(FUNDING_PER_USER);
         await addFundingFromUser1(FUNDING_PER_USER);
-        expect(await insuredVesting.methods.usdcVestedFor(user1).call()).to.be.bignumber.eq(0);
+        expect(await insuredVesting.methods.fundingTokenVestedFor(user1).call()).to.be.bignumber.eq(0);
       });
 
       it("returns correct vested amount - immediately after activation", async () => {
-        await setAllocationForUser1(FUNDING_PER_USER);
+        await setAllowedAllocationForUser1(FUNDING_PER_USER);
         await addFundingFromUser1(FUNDING_PER_USER);
         await insuredVesting.methods.activate().send({ from: deployer });
-        expect(await insuredVesting.methods.usdcVestedFor(user1).call()).to.be.bignumber.eq(0);
+        expect(await insuredVesting.methods.fundingTokenVestedFor(user1).call()).to.be.bignumber.eq(0);
       });
 
       it("returns correct vested amount - 30 days", async () => {
-        await setAllocationForUser1(FUNDING_PER_USER);
+        await setAllowedAllocationForUser1(FUNDING_PER_USER);
         await addFundingFromUser1(FUNDING_PER_USER);
         await insuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(30);
-        expect(await insuredVesting.methods.usdcVestedFor(user1).call()).to.be.bignumber.eq(await vestedAmount(30, "usdc"));
+        expect(await insuredVesting.methods.fundingTokenVestedFor(user1).call()).to.be.bignumber.eq(await vestedAmount(30, "fundingToken"));
       });
     });
   });
 
   describe("activate", () => {
-    it("fails if there isn't enough XCTD allowance to cover funded USDC", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("fails if there isn't enough PROJECT_TOKEN allowance to cover funded FUNDING_TOKEN", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
       await expectRevert(async () => insuredVesting.methods.activate().send({ from: deployer }), "ERC20: insufficient allowance");
     });
 
-    it("fails if there isn't enough XCTD balance to cover funded USDC", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("fails if there isn't enough PROJECT_TOKEN balance to cover funded FUNDING_TOKEN", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
       // Get rid of all balance
-      await xctd.methods.transfer(anyUser, await xctd.amount(1e9)).send({ from: project });
+      await projectToken.methods.transfer(anyUser, await projectToken.amount(1e9)).send({ from: projectWallet });
       await expectRevert(async () => insuredVesting.methods.activate().send({ from: deployer }), "ERC20: transfer amount exceeds balance");
     });
 
-    it("transfers XCTD required to back USDC funding", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("transfers PROJECT_TOKEN required to back FUNDING_TOKEN funding", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER / 4);
 
-      const requiredXctd = await xctd.amount((FUNDING_PER_USER / 4) * USDC_TO_XCTD_RATIO);
+      const requiredProjectToken = await projectToken.amount((FUNDING_PER_USER / 4) * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO);
 
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
 
       await insuredVesting.methods.activate().send({ from: deployer });
 
-      const contractXctdBalance = await xctd.methods.balanceOf(insuredVesting.options.address).call();
+      const contractProjectTokenBalance = await projectToken.methods.balanceOf(insuredVesting.options.address).call();
 
-      expect(contractXctdBalance).to.be.bignumber.eq(requiredXctd);
+      expect(contractProjectTokenBalance).to.be.bignumber.eq(requiredProjectToken);
     });
 
-    it("does not transfer XCTD if already funded sufficiently", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("does not transfer PROJECT_TOKEN if already funded sufficiently", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
 
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
 
-      await xctd.methods.transfer(insuredVesting.options.address, await xctd.amount(FUNDING_PER_USER * 10)).send({ from: project });
+      await projectToken.methods.transfer(insuredVesting.options.address, await projectToken.amount(FUNDING_PER_USER * 10)).send({ from: projectWallet });
 
-      const initialContractXctdBalance = await xctd.methods.balanceOf(insuredVesting.options.address).call();
+      const initialContractProjectTokenBalance = await projectToken.methods.balanceOf(insuredVesting.options.address).call();
       await insuredVesting.methods.activate().send({ from: deployer });
-      const contractXctdBalance = await xctd.methods.balanceOf(insuredVesting.options.address).call();
+      const contractProjectTokenBalance = await projectToken.methods.balanceOf(insuredVesting.options.address).call();
 
-      expect(initialContractXctdBalance).to.be.bignumber.eq(contractXctdBalance);
+      expect(initialContractProjectTokenBalance).to.be.bignumber.eq(contractProjectTokenBalance);
     });
 
-    it("transfers XCTD required to back USDC funding (partially pre-funded)", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("transfers PROJECT_TOKEN required to back FUNDING_TOKEN funding (partially pre-funded)", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
 
-      const requiredXctd = await xctd.amount(FUNDING_PER_USER * USDC_TO_XCTD_RATIO);
+      const requiredProjectToken = await projectToken.amount(FUNDING_PER_USER * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO);
 
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
 
-      await xctd.methods.transfer(insuredVesting.options.address, await xctd.amount(FUNDING_PER_USER / 3)).send({ from: project });
+      await projectToken.methods.transfer(insuredVesting.options.address, await projectToken.amount(FUNDING_PER_USER / 3)).send({ from: projectWallet });
 
       await insuredVesting.methods.activate().send({ from: deployer });
 
-      const contractXctdBalance = await xctd.methods.balanceOf(insuredVesting.options.address).call();
+      const contractProjectTokenBalance = await projectToken.methods.balanceOf(insuredVesting.options.address).call();
 
-      expect(contractXctdBalance).to.be.bignumber.eq(requiredXctd);
+      expect(contractProjectTokenBalance).to.be.bignumber.eq(requiredProjectToken);
     });
 
     it("fails if already activated", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
 
       await insuredVesting.methods.activate().send({ from: deployer });
 
@@ -875,7 +886,7 @@ describe("InsuredVestingV1", () => {
     });
 
     it("fails if not owner", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
 
       await expectRevert(async () => insuredVesting.methods.activate().send({ from: anyUser }), "Ownable: caller is not the owner");
@@ -886,42 +897,25 @@ describe("InsuredVestingV1", () => {
     });
 
     it("activates", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
 
       await insuredVesting.methods.activate().send({ from: deployer });
 
-      expect(await insuredVesting.methods.startTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
+      expect(await insuredVesting.methods.vestingStartTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
     });
 
-    it("tranfers the correct amount of xctd after setting allocations with refunds", async () => {
-      await setAllocationForUser1(FUNDING_PER_USER);
+    it("tranfers the correct amount of PROJECT_TOKEN after setting allowed allocations with refunds", async () => {
+      await setAllowedAllocationForUser1(FUNDING_PER_USER);
       await addFundingFromUser1(FUNDING_PER_USER);
-      await setAllocationForUser2(FUNDING_PER_USER);
+      await setAllowedAllocationForUser2(FUNDING_PER_USER);
       await addFundingFromUser2(FUNDING_PER_USER);
-      // Reduce allocation
-      await setAllocationForUser2(FUNDING_PER_USER / 2);
+      // Reduce allowed allocation
+      await setAllowedAllocationForUser2(FUNDING_PER_USER / 2);
 
-      await approveXctdToVesting((FUNDING_PER_USER + FUNDING_PER_USER / 2) * USDC_TO_XCTD_RATIO);
+      await approveProjectTokenToVesting((FUNDING_PER_USER + FUNDING_PER_USER / 2) * FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO);
       await insuredVesting.methods.activate().send({ from: deployer });
-    });
-  });
-
-  describe("deployment", () => {
-    describe("project address", () => {
-      it("project address cannot be zero", async () => {
-        // TODO TEMPORARY: until having production XCTD & project addresses
-        const testConfig = [...config];
-        testConfig[1] = xctd.options.address;
-        testConfig[2] = zeroAddress;
-        // END TEMPORARY
-        await expectRevert(async () => deployArtifact<InsuredVestingV1>("InsuredVestingV1", { from: deployer }, testConfig), Error.ZeroAddress);
-      });
-
-      it("project address should be set correctly", async () => {
-        expect(await insuredVesting.methods.project().call()).to.be.eq(project);
-      });
     });
   });
 });

--- a/test/uninsured-vesting-v1/deployment.test.ts
+++ b/test/uninsured-vesting-v1/deployment.test.ts
@@ -1,27 +1,27 @@
 import { expect, assert } from "chai";
-import { withFixture, setup, uninsuredVesting } from "./fixture";
+import { withFixture, setup, vesting } from "./fixture";
 import BN from "bignumber.js";
 import sinon from "sinon";
 
 import { zeroAddress } from "@defi.org/web3-candies";
-import { ConfigTuple, deployUninsuredVestingV1 } from "../../deployment/uninsured-vesting-v1";
+import { ConfigTuple, deployVestingV1 } from "../../deployment/uninsured-vesting-v1";
 
-describe("UninsuredVestingV1 deployment config", () => {
+describe("VestingV1 deployment config", () => {
   before(async () => await setup());
 
   beforeEach(async () => withFixture());
 
   // TODO: reenable this when config is using real XCTD address
   it.skip("xctd address cannot be zero", async () => {
-    expect((await uninsuredVesting.methods.PROJECT_TOKEN().call()).toLowerCase()).to.not.match(/^0x0+$/);
+    expect((await vesting.methods.PROJECT_TOKEN().call()).toLowerCase()).to.not.match(/^0x0+$/);
   });
 
   it("duration is 2 years", async () => {
-    expect(await uninsuredVesting.methods.VESTING_DURATION_SECONDS().call()).to.equal(String(60 * 60 * 24 * 365 * 2));
+    expect(await vesting.methods.VESTING_DURATION_SECONDS().call()).to.equal(String(60 * 60 * 24 * 365 * 2));
   });
 });
 
-describe("UninsuredVestingV1 deployment script", () => {
+describe("VestingV1 deployment script", () => {
   const web3CandiesStub = {
     deploy: sinon.stub(),
   };
@@ -39,7 +39,7 @@ describe("UninsuredVestingV1 deployment script", () => {
     for (const { config, errorMessage } of testCases) {
       it(errorMessage, async () => {
         try {
-          await deployUninsuredVestingV1(web3CandiesStub.deploy, config, new BN(10), new BN(10));
+          await deployVestingV1(web3CandiesStub.deploy, config, new BN(10), new BN(10));
           assert.fail("should have thrown error");
         } catch (error: any) {
           expect(error.message).to.equal(errorMessage);
@@ -50,10 +50,10 @@ describe("UninsuredVestingV1 deployment script", () => {
 
   describe("Success", () => {
     it("should deploy", async () => {
-      await deployUninsuredVestingV1(web3CandiesStub.deploy, ["0x123", 63_072_000], new BN(10), new BN(10));
+      await deployVestingV1(web3CandiesStub.deploy, ["0x123", 63_072_000], new BN(10), new BN(10));
       expect(web3CandiesStub.deploy.calledOnce).to.be.true;
       expect(web3CandiesStub.deploy.firstCall.args[0]).to.deep.equal({
-        contractName: "UninsuredVestingV1",
+        contractName: "VestingV1",
         args: ["0x123", 63_072_000],
         maxFeePerGas: new BN(10),
         maxPriorityFeePerGas: new BN(10),

--- a/test/uninsured-vesting-v1/deployment.test.ts
+++ b/test/uninsured-vesting-v1/deployment.test.ts
@@ -5,7 +5,6 @@ import sinon from "sinon";
 
 import { zeroAddress } from "@defi.org/web3-candies";
 import { ConfigTuple, deployUninsuredVestingV1 } from "../../deployment/uninsured-vesting-v1";
-import { VESTING_DURATION_SECONDS } from "../insured-vesting-v1/fixture";
 
 describe("UninsuredVestingV1 deployment config", () => {
   before(async () => await setup());
@@ -14,7 +13,7 @@ describe("UninsuredVestingV1 deployment config", () => {
 
   // TODO: reenable this when config is using real XCTD address
   it.skip("xctd address cannot be zero", async () => {
-    expect((await uninsuredVesting.methods.XCTD().call()).toLowerCase()).to.not.match(/^0x0+$/);
+    expect((await uninsuredVesting.methods.PROJECT_TOKEN().call()).toLowerCase()).to.not.match(/^0x0+$/);
   });
 
   it("duration is 2 years", async () => {

--- a/test/uninsured-vesting-v1/fixture.ts
+++ b/test/uninsured-vesting-v1/fixture.ts
@@ -1,4 +1,4 @@
-import { Token, account, bn18, erc20, BlockInfo, Receipt, web3 } from "@defi.org/web3-candies";
+import { Token, account, bn18, erc20, BlockInfo, web3 } from "@defi.org/web3-candies";
 import { deployArtifact, mineBlock, tag, useChaiBigNumber } from "@defi.org/web3-candies/dist/hardhat";
 import BN from "bignumber.js";
 import { UninsuredVestingV1 } from "../../typechain-hardhat/contracts/uninsured-vesting-v1/UninsuredVestingV1";
@@ -12,7 +12,7 @@ export let user1: string;
 export let user2: string;
 export let anyUser: string;
 
-export let xctd: MockERC20 & Token;
+export let projectToken: MockERC20 & Token;
 export let someOtherToken: MockERC20 & Token;
 export let uninsuredVesting: UninsuredVestingV1;
 
@@ -20,8 +20,8 @@ export const DAY = 60 * 60 * 24;
 export const MONTH = DAY * 30;
 export const VESTING_DURATION_SECONDS = DAY * 730;
 
-export const XCTD_TOKENS_ON_SALE = 1_000_000;
-export const USDC_TO_XCTD_RATIO = 7;
+export const PROJECT_TOKENS_ON_SALE = 1_000_000;
+export const FUNDING_TOKEN_TO_PROJECT_TOKEN_RATIO = 7;
 export const LOCKUP_MONTHS = 6;
 export const TOKENS_PER_USER = 10_000;
 
@@ -37,12 +37,12 @@ export async function setup() {
 }
 
 export async function withFixture() {
-  xctd = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "XCTD"])).options.address);
+  projectToken = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "ProjectToken"])).options.address);
   someOtherToken = erc20("MockERC20", (await deployArtifact<MockERC20>("MockERC20", { from: deployer }, [bn18(1e9), "SomeOtherToken"])).options.address);
 
-  // TODO TEMPORARY: until having production XCTD address
+  // TODO TEMPORARY: until having production PROJECT_TOKEN address
   const testConfig = [...config];
-  testConfig[0] = xctd.options.address;
+  testConfig[0] = projectToken.options.address;
   // END TEMPORARY
 
   uninsuredVesting = await deployArtifact<UninsuredVestingV1>("UninsuredVestingV1", { from: deployer }, testConfig);
@@ -59,12 +59,12 @@ export enum Error {
   OnlyOwnerOrSender = "OnlyOwnerOrSender",
 }
 
-export async function transferXctdToVesting() {
-  await xctd.methods.transfer(uninsuredVesting.options.address, await xctd.amount(XCTD_TOKENS_ON_SALE)).send({ from: deployer });
+export async function transferProjectTokenToVesting() {
+  await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(PROJECT_TOKENS_ON_SALE)).send({ from: deployer });
 }
 
-export async function approveXctdToVesting(amount = XCTD_TOKENS_ON_SALE) {
-  await xctd.methods.approve(uninsuredVesting.options.address, await xctd.amount(amount)).send({ from: deployer });
+export async function approveProjectTokenToVesting(amount = PROJECT_TOKENS_ON_SALE) {
+  await projectToken.methods.approve(uninsuredVesting.options.address, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export function advanceDays(days: number): Promise<BlockInfo> {
@@ -84,16 +84,16 @@ export async function getDefaultStartTime(): Promise<BN> {
 }
 
 export async function setAmountForUser1(amount = TOKENS_PER_USER) {
-  await uninsuredVesting.methods.setAmount(user1, await xctd.amount(amount)).send({ from: deployer });
+  await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export async function setAmountForUser2(amount = TOKENS_PER_USER) {
-  await uninsuredVesting.methods.setAmount(user2, await xctd.amount(amount)).send({ from: deployer });
+  await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export async function vestedAmount(days: number) {
   let amount = BN(TOKENS_PER_USER)
     .dividedBy(VESTING_DURATION_SECONDS)
     .multipliedBy(DAY * days);
-  return xctd.amount(amount);
+  return projectToken.amount(amount);
 }

--- a/test/uninsured-vesting-v1/fixture.ts
+++ b/test/uninsured-vesting-v1/fixture.ts
@@ -1,7 +1,7 @@
 import { Token, account, bn18, erc20, BlockInfo, web3 } from "@defi.org/web3-candies";
 import { deployArtifact, mineBlock, tag, useChaiBigNumber } from "@defi.org/web3-candies/dist/hardhat";
 import BN from "bignumber.js";
-import { UninsuredVestingV1 } from "../../typechain-hardhat/contracts/uninsured-vesting-v1/UninsuredVestingV1";
+import { VestingV1 } from "../../typechain-hardhat/contracts/uninsured-vesting-v1/UninsuredVestingV1.sol";
 import { MockERC20 } from "../../typechain-hardhat/contracts/test/MockERC20";
 import { config } from "../../deployment/uninsured-vesting-v1/config";
 
@@ -14,7 +14,7 @@ export let anyUser: string;
 
 export let projectToken: MockERC20 & Token;
 export let someOtherToken: MockERC20 & Token;
-export let uninsuredVesting: UninsuredVestingV1;
+export let vesting: VestingV1;
 
 export const DAY = 60 * 60 * 24;
 export const MONTH = DAY * 30;
@@ -45,7 +45,7 @@ export async function withFixture() {
   testConfig[0] = projectToken.options.address;
   // END TEMPORARY
 
-  uninsuredVesting = await deployArtifact<UninsuredVestingV1>("UninsuredVestingV1", { from: deployer }, testConfig);
+  vesting = await deployArtifact<VestingV1>("VestingV1", { from: deployer }, testConfig);
 }
 
 export enum Error {
@@ -60,11 +60,11 @@ export enum Error {
 }
 
 export async function transferProjectTokenToVesting() {
-  await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(PROJECT_TOKENS_ON_SALE)).send({ from: deployer });
+  await projectToken.methods.transfer(vesting.options.address, await projectToken.amount(PROJECT_TOKENS_ON_SALE)).send({ from: deployer });
 }
 
 export async function approveProjectTokenToVesting(amount = PROJECT_TOKENS_ON_SALE) {
-  await projectToken.methods.approve(uninsuredVesting.options.address, await projectToken.amount(amount)).send({ from: deployer });
+  await projectToken.methods.approve(vesting.options.address, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export function advanceDays(days: number): Promise<BlockInfo> {
@@ -84,11 +84,11 @@ export async function getDefaultStartTime(): Promise<BN> {
 }
 
 export async function setAmountForUser1(amount = TOKENS_PER_USER) {
-  await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(amount)).send({ from: deployer });
+  await vesting.methods.setAmount(user1, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export async function setAmountForUser2(amount = TOKENS_PER_USER) {
-  await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(amount)).send({ from: deployer });
+  await vesting.methods.setAmount(user2, await projectToken.amount(amount)).send({ from: deployer });
 }
 
 export async function vestedAmount(days: number) {

--- a/test/uninsured-vesting-v1/uninsured-vesting-v1.test.ts
+++ b/test/uninsured-vesting-v1/uninsured-vesting-v1.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "chai";
 import BN from "bignumber.js";
-import { deployArtifact, expectRevert, setBalance } from "@defi.org/web3-candies/dist/hardhat";
+import { expectRevert, setBalance } from "@defi.org/web3-candies/dist/hardhat";
 import {
   anyUser,
   user1,
   uninsuredVesting,
   withFixture,
-  xctd,
+  projectToken,
   TOKENS_PER_USER,
   deployer,
   getCurrentTimestamp,
@@ -16,25 +16,23 @@ import {
   advanceDays,
   DAY,
   VESTING_DURATION_SECONDS,
-  approveXctdToVesting,
-  transferXctdToVesting,
+  approveProjectTokenToVesting,
+  transferProjectTokenToVesting,
   setAmountForUser1,
   setAmountForUser2,
   setup,
   vestedAmount,
 } from "./fixture";
 import { web3 } from "@defi.org/web3-candies";
-import { UninsuredVestingV1 } from "../../typechain-hardhat/contracts/uninsured-vesting-v1/UninsuredVestingV1";
-import { config } from "../../deployment/uninsured-vesting-v1/config";
 
 describe("UninsuredVestingV1", () => {
   before(async () => await setup());
 
   beforeEach(async () => withFixture());
 
-  describe("with xctd approved to contract", () => {
+  describe("with projectToken approved to contract", () => {
     beforeEach(async () => {
-      transferXctdToVesting();
+      transferProjectTokenToVesting();
     });
 
     describe("claim", () => {
@@ -42,79 +40,85 @@ describe("UninsuredVestingV1", () => {
 
       for (const days of testCases) {
         it(`can claim tokens proportional to amount of seconds in ${days} days passed`, async () => {
-          await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+          await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
           await uninsuredVesting.methods.activate().send({ from: deployer });
           await advanceDays(days);
           await uninsuredVesting.methods.claim(user1).send({ from: user1 });
 
-          expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
-            (await xctd.amount(TOKENS_PER_USER)).multipliedBy(days * DAY).dividedBy(VESTING_DURATION_SECONDS),
-            await xctd.amount(0.01)
+          expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+            (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(days * DAY).dividedBy(VESTING_DURATION_SECONDS),
+            await projectToken.amount(0.01)
           );
         });
       }
 
       it(`can claim tokens for the entire period`, async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_SECONDS);
         await uninsuredVesting.methods.claim(user1).send({ from: user1 });
 
-        expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(await xctd.amount(TOKENS_PER_USER), await xctd.amount(0.01));
+        expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+          await projectToken.amount(TOKENS_PER_USER),
+          await projectToken.amount(0.01)
+        );
       });
 
       it(`can claim tokens for the entire period, longer than vesting period has passed`, async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_SECONDS * 2);
         await uninsuredVesting.methods.claim(user1).send({ from: user1 });
 
-        expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(await xctd.amount(TOKENS_PER_USER), await xctd.amount(0.01));
+        expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+          await projectToken.amount(TOKENS_PER_USER),
+          await projectToken.amount(0.01)
+        );
       });
 
       it("cannot double-claim tokens for same period of time", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         const daysToAdvance = 66;
         await advanceDays(daysToAdvance);
 
         await uninsuredVesting.methods.claim(user1).send({ from: user1 });
-        const balanceAfterFirstClaim = await xctd.methods.balanceOf(user1).call();
+        const balanceAfterFirstClaim = await projectToken.methods.balanceOf(user1).call();
         expect(balanceAfterFirstClaim).to.be.bignumber.closeTo(
-          (await xctd.amount(TOKENS_PER_USER)).multipliedBy(daysToAdvance * DAY).dividedBy(VESTING_DURATION_SECONDS),
-          await xctd.amount(0.01)
+          (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(daysToAdvance * DAY).dividedBy(VESTING_DURATION_SECONDS),
+          await projectToken.amount(0.01)
         );
 
         await uninsuredVesting.methods.claim(user1).send({ from: user1 });
-        expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(balanceAfterFirstClaim, await xctd.amount(0.01));
+        expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(balanceAfterFirstClaim, await projectToken.amount(0.01));
       });
 
       it("cannot claim tokens before starting period", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: user1 }), Error.VestingNotStarted);
       });
 
       it("cannot claim if there's no eligibility", async () => {
-        await uninsuredVesting.methods.setAmount(user2, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(1);
         await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: user1 }), Error.NothingToClaim);
       });
 
       it("owner can claim on behalf of user", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(70);
         await uninsuredVesting.methods.claim(user1).send({ from: deployer });
 
-        expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
-          (await xctd.amount(TOKENS_PER_USER)).multipliedBy(70 * DAY).dividedBy(VESTING_DURATION_SECONDS),
-          await xctd.amount(0.01)
+        expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+          (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(70 * DAY).dividedBy(VESTING_DURATION_SECONDS),
+          await projectToken.amount(0.01)
         );
       });
 
       it("cannot claim if not user or project", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
         await advanceDays(70);
         await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: anyUser }), Error.OnlyOwnerOrSender);
@@ -126,7 +130,7 @@ describe("UninsuredVestingV1", () => {
         const startingBalance = await web3().eth.getBalance(deployer);
         expect(await web3().eth.getBalance(uninsuredVesting.options.address)).to.bignumber.eq(0);
         await setBalance(uninsuredVesting.options.address, BN(12345 * 1e18));
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         expect(await web3().eth.getBalance(uninsuredVesting.options.address)).to.be.bignumber.zero;
         expect(await web3().eth.getBalance(deployer)).to.bignumber.closeTo(BN(12345 * 1e18).plus(startingBalance), BN(0.1e18));
       });
@@ -137,42 +141,51 @@ describe("UninsuredVestingV1", () => {
         expect(await someOtherToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.zero;
       });
 
-      it("recovers excess xctd, some allocations set", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.setAmount(user2, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
+      it("recovers excess projectToken, some allocations set", async () => {
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
         // Recover all but the tokens allocated to users
-        expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER * 2));
+        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
+          await projectToken.amount(TOKENS_PER_USER * 2)
+        );
       });
 
-      it("recovers excess xctd, no allocations set", async () => {
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(0));
+      it("recovers excess projectToken, no allocations set", async () => {
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(0));
       });
 
-      it("recovers excess xctd, recovery called multiple times is idempotent", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER / 4));
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER / 4));
+      it("recovers excess projectToken, recovery called multiple times is idempotent", async () => {
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
+          await projectToken.amount(TOKENS_PER_USER / 4)
+        );
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
+          await projectToken.amount(TOKENS_PER_USER / 4)
+        );
       });
 
       it("can still recover excess funds after some already claimed", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
         await uninsuredVesting.methods.activate().send({ from: deployer });
 
         advanceDays(30);
 
-        const currentUserBalance = BN(await xctd.methods.balanceOf(user1).call());
+        const currentUserBalance = BN(await projectToken.methods.balanceOf(user1).call());
 
         await uninsuredVesting.methods.claim(user1).send({ from: user1 });
 
-        expect(await xctd.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(currentUserBalance.plus(await vestedAmount(30)), await xctd.amount(0.1));
+        expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
+          currentUserBalance.plus(await vestedAmount(30)),
+          await projectToken.amount(0.1)
+        );
 
-        await uninsuredVesting.methods.recover(xctd.options.address).send({ from: deployer });
-        expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
+        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
       });
 
       it("handles zero token balance gracefully", async () => {
@@ -193,7 +206,10 @@ describe("UninsuredVestingV1", () => {
       });
 
       it("cannot recover if not owner", async () => {
-        await expectRevert(async () => uninsuredVesting.methods.recover(xctd.options.address).send({ from: anyUser }), "Ownable: caller is not the owner");
+        await expectRevert(
+          async () => uninsuredVesting.methods.recover(projectToken.options.address).send({ from: anyUser }),
+          "Ownable: caller is not the owner"
+        );
       });
     });
 
@@ -211,42 +227,44 @@ describe("UninsuredVestingV1", () => {
           });
 
           it("single user", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
           });
 
           it("single user, amount updated to same amount as previously", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
           });
 
           it("multiple users", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(3_500)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await xctd.amount(1_000)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await xctd.amount(3_500));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await xctd.amount(1_000));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await (await xctd.amount(3_500)).plus(await xctd.amount(1_000)));
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(3_500)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(1_000)).send({ from: deployer });
+            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_500));
+            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(1_000));
+            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(
+              await (await projectToken.amount(3_500)).plus(await projectToken.amount(1_000))
+            );
           });
 
           it("multiple users, amount reduced", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(10_000)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await xctd.amount(10_000)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(3_000)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await xctd.amount(3_000));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await xctd.amount(10_000));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await xctd.amount(13_000));
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(10_000)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(10_000)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(3_000)).send({ from: deployer });
+            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_000));
+            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(10_000));
+            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(13_000));
           });
 
           it("multiple users, amount reduced to zero", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await xctd.amount(0)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await xctd.amount(0));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await xctd.amount(TOKENS_PER_USER));
+            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(0)).send({ from: deployer });
+            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(0));
+            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(TOKENS_PER_USER));
           });
         });
       });
@@ -254,48 +272,48 @@ describe("UninsuredVestingV1", () => {
   });
 
   describe("activate", () => {
-    it("fails if there isn't enough XCTD allowance to cover total allocated", async () => {
+    it("fails if there isn't enough PROJECT_TOKEN allowance to cover total allocated", async () => {
       await setAmountForUser1();
       await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), "ERC20: insufficient allowance");
     });
 
-    it("fails if there isn't enough XCTD balance to cover total allocated", async () => {
+    it("fails if there isn't enough PROJECT_TOKEN balance to cover total allocated", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
       // Get rid of all balance
-      await xctd.methods.transfer(anyUser, await xctd.amount(1e9)).send({ from: deployer });
+      await projectToken.methods.transfer(anyUser, await projectToken.amount(1e9)).send({ from: deployer });
       await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), "ERC20: transfer amount exceeds balance");
     });
 
-    it("transfers XCTD proportional to total allocated", async () => {
+    it("transfers PROJECT_TOKEN proportional to total allocated", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
       await uninsuredVesting.methods.activate().send({ from: deployer });
-      expect(await xctd.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
+      expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
     });
 
-    it("does not transfer XCTD if already funded sufficiently", async () => {
+    it("does not transfer PROJECT_TOKEN if already funded sufficiently", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
-      await xctd.methods.transfer(uninsuredVesting.options.address, await xctd.amount(TOKENS_PER_USER)).send({ from: deployer });
-      const initialContractXctdBalance = await xctd.methods.balanceOf(uninsuredVesting.options.address).call();
+      await approveProjectTokenToVesting();
+      await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+      const initialContractProjectTokenBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
       await uninsuredVesting.methods.activate().send({ from: deployer });
-      const currentContractBalance = await xctd.methods.balanceOf(uninsuredVesting.options.address).call();
-      expect(initialContractXctdBalance).to.be.bignumber.eq(currentContractBalance);
+      const currentContractBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
+      expect(initialContractProjectTokenBalance).to.be.bignumber.eq(currentContractBalance);
     });
 
-    it("transfers XCTD required to back USDC funding (partially pre-funded)", async () => {
+    it("transfers PROJECT_TOKEN required to back FUNDING_TOKEN funding (partially pre-funded)", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
-      await xctd.methods.transfer(uninsuredVesting.options.address, await xctd.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
+      await approveProjectTokenToVesting();
+      await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
       await uninsuredVesting.methods.activate().send({ from: deployer });
-      const contractXctdBalance = await xctd.methods.balanceOf(uninsuredVesting.options.address).call();
-      expect(contractXctdBalance).to.be.bignumber.eq(await xctd.amount(TOKENS_PER_USER));
+      const contractProjectTokenBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
+      expect(contractProjectTokenBalance).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
     });
 
     it("fails if already activated", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
       await uninsuredVesting.methods.activate().send({ from: deployer });
       await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), Error.VestingAlreadyStarted);
     });
@@ -306,9 +324,9 @@ describe("UninsuredVestingV1", () => {
 
     it("sets start time", async () => {
       await setAmountForUser1();
-      await approveXctdToVesting();
+      await approveProjectTokenToVesting();
       await uninsuredVesting.methods.activate().send({ from: deployer });
-      expect(await uninsuredVesting.methods.startTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
+      expect(await uninsuredVesting.methods.vestingStartTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
     });
   });
 

--- a/test/uninsured-vesting-v1/uninsured-vesting-v1.test.ts
+++ b/test/uninsured-vesting-v1/uninsured-vesting-v1.test.ts
@@ -4,7 +4,7 @@ import { expectRevert, setBalance } from "@defi.org/web3-candies/dist/hardhat";
 import {
   anyUser,
   user1,
-  uninsuredVesting,
+  vesting,
   withFixture,
   projectToken,
   TOKENS_PER_USER,
@@ -25,7 +25,7 @@ import {
 } from "./fixture";
 import { web3 } from "@defi.org/web3-candies";
 
-describe("UninsuredVestingV1", () => {
+describe("VestingV1", () => {
   before(async () => await setup());
 
   beforeEach(async () => withFixture());
@@ -40,10 +40,10 @@ describe("UninsuredVestingV1", () => {
 
       for (const days of testCases) {
         it(`can claim tokens proportional to amount of seconds in ${days} days passed`, async () => {
-          await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-          await uninsuredVesting.methods.activate().send({ from: deployer });
+          await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+          await vesting.methods.activate().send({ from: deployer });
           await advanceDays(days);
-          await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+          await vesting.methods.claim(user1).send({ from: user1 });
 
           expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
             (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(days * DAY).dividedBy(VESTING_DURATION_SECONDS),
@@ -53,10 +53,10 @@ describe("UninsuredVestingV1", () => {
       }
 
       it(`can claim tokens for the entire period`, async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_SECONDS);
-        await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+        await vesting.methods.claim(user1).send({ from: user1 });
 
         expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
           await projectToken.amount(TOKENS_PER_USER),
@@ -65,10 +65,10 @@ describe("UninsuredVestingV1", () => {
       });
 
       it(`can claim tokens for the entire period, longer than vesting period has passed`, async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         await advanceDays(VESTING_DURATION_SECONDS * 2);
-        await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+        await vesting.methods.claim(user1).send({ from: user1 });
 
         expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
           await projectToken.amount(TOKENS_PER_USER),
@@ -77,39 +77,39 @@ describe("UninsuredVestingV1", () => {
       });
 
       it("cannot double-claim tokens for same period of time", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         const daysToAdvance = 66;
         await advanceDays(daysToAdvance);
 
-        await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+        await vesting.methods.claim(user1).send({ from: user1 });
         const balanceAfterFirstClaim = await projectToken.methods.balanceOf(user1).call();
         expect(balanceAfterFirstClaim).to.be.bignumber.closeTo(
           (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(daysToAdvance * DAY).dividedBy(VESTING_DURATION_SECONDS),
           await projectToken.amount(0.01)
         );
 
-        await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+        await vesting.methods.claim(user1).send({ from: user1 });
         expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(balanceAfterFirstClaim, await projectToken.amount(0.01));
       });
 
       it("cannot claim tokens before starting period", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: user1 }), Error.VestingNotStarted);
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await expectRevert(() => vesting.methods.claim(user1).send({ from: user1 }), Error.VestingNotStarted);
       });
 
       it("cannot claim if there's no eligibility", async () => {
-        await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         await advanceDays(1);
-        await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: user1 }), Error.NothingToClaim);
+        await expectRevert(() => vesting.methods.claim(user1).send({ from: user1 }), Error.NothingToClaim);
       });
 
       it("owner can claim on behalf of user", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         await advanceDays(70);
-        await uninsuredVesting.methods.claim(user1).send({ from: deployer });
+        await vesting.methods.claim(user1).send({ from: deployer });
 
         expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
           (await projectToken.amount(TOKENS_PER_USER)).multipliedBy(70 * DAY).dividedBy(VESTING_DURATION_SECONDS),
@@ -118,98 +118,89 @@ describe("UninsuredVestingV1", () => {
       });
 
       it("cannot claim if not user or project", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
         await advanceDays(70);
-        await expectRevert(() => uninsuredVesting.methods.claim(user1).send({ from: anyUser }), Error.OnlyOwnerOrSender);
+        await expectRevert(() => vesting.methods.claim(user1).send({ from: anyUser }), Error.OnlyOwnerOrSender);
       });
     });
 
     describe("recovery", () => {
       it("recovers ether", async () => {
         const startingBalance = await web3().eth.getBalance(deployer);
-        expect(await web3().eth.getBalance(uninsuredVesting.options.address)).to.bignumber.eq(0);
-        await setBalance(uninsuredVesting.options.address, BN(12345 * 1e18));
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        expect(await web3().eth.getBalance(uninsuredVesting.options.address)).to.be.bignumber.zero;
+        expect(await web3().eth.getBalance(vesting.options.address)).to.bignumber.eq(0);
+        await setBalance(vesting.options.address, BN(12345 * 1e18));
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await web3().eth.getBalance(vesting.options.address)).to.be.bignumber.zero;
         expect(await web3().eth.getBalance(deployer)).to.bignumber.closeTo(BN(12345 * 1e18).plus(startingBalance), BN(0.1e18));
       });
 
       it("recovers other tokens", async () => {
-        await someOtherToken.methods.transfer(uninsuredVesting.options.address, BN(12345 * 1e18)).send({ from: deployer });
-        await uninsuredVesting.methods.recover(someOtherToken.options.address).send({ from: deployer });
-        expect(await someOtherToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.zero;
+        await someOtherToken.methods.transfer(vesting.options.address, BN(12345 * 1e18)).send({ from: deployer });
+        await vesting.methods.recover(someOtherToken.options.address).send({ from: deployer });
+        expect(await someOtherToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.zero;
       });
 
       it("recovers excess projectToken, some allocations set", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
         // Recover all but the tokens allocated to users
-        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
-          await projectToken.amount(TOKENS_PER_USER * 2)
-        );
+        expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER * 2));
       });
 
       it("recovers excess projectToken, no allocations set", async () => {
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(0));
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(0));
       });
 
       it("recovers excess projectToken, recovery called multiple times is idempotent", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
-          await projectToken.amount(TOKENS_PER_USER / 4)
-        );
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(
-          await projectToken.amount(TOKENS_PER_USER / 4)
-        );
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER / 4));
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER / 4));
       });
 
       it("can still recover excess funds after some already claimed", async () => {
-        await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-        await uninsuredVesting.methods.activate().send({ from: deployer });
+        await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+        await vesting.methods.activate().send({ from: deployer });
 
         advanceDays(30);
 
         const currentUserBalance = BN(await projectToken.methods.balanceOf(user1).call());
 
-        await uninsuredVesting.methods.claim(user1).send({ from: user1 });
+        await vesting.methods.claim(user1).send({ from: user1 });
 
         expect(await projectToken.methods.balanceOf(user1).call()).to.be.bignumber.closeTo(
           currentUserBalance.plus(await vestedAmount(30)),
           await projectToken.amount(0.1)
         );
 
-        await uninsuredVesting.methods.recover(projectToken.options.address).send({ from: deployer });
-        expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+        await vesting.methods.recover(projectToken.options.address).send({ from: deployer });
+        expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
       });
 
       it("handles zero token balance gracefully", async () => {
-        const startingBalance = await someOtherToken.methods.balanceOf(uninsuredVesting.options.address).call();
+        const startingBalance = await someOtherToken.methods.balanceOf(vesting.options.address).call();
         expect(startingBalance).to.be.bignumber.zero;
-        await uninsuredVesting.methods.recover(someOtherToken.options.address).send({ from: deployer });
-        expect(await someOtherToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.zero;
+        await vesting.methods.recover(someOtherToken.options.address).send({ from: deployer });
+        expect(await someOtherToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.zero;
       });
     });
 
     describe("access control", () => {
       it("cannot call activate if not owner", async () => {
-        await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: anyUser }), "Ownable: caller is not the owner");
+        await expectRevert(async () => vesting.methods.activate().send({ from: anyUser }), "Ownable: caller is not the owner");
       });
 
       it("cannot set amounts if not owner", async () => {
-        await expectRevert(async () => uninsuredVesting.methods.setAmount(user1, 1).send({ from: anyUser }), "Ownable: caller is not the owner");
+        await expectRevert(async () => vesting.methods.setAmount(user1, 1).send({ from: anyUser }), "Ownable: caller is not the owner");
       });
 
       it("cannot recover if not owner", async () => {
-        await expectRevert(
-          async () => uninsuredVesting.methods.recover(projectToken.options.address).send({ from: anyUser }),
-          "Ownable: caller is not the owner"
-        );
+        await expectRevert(async () => vesting.methods.recover(projectToken.options.address).send({ from: anyUser }), "Ownable: caller is not the owner");
       });
     });
 
@@ -217,54 +208,54 @@ describe("UninsuredVestingV1", () => {
       describe("set amount", () => {
         it("cannot set amount after period started", async () => {
           await setAmountForUser1();
-          await uninsuredVesting.methods.activate().send({ from: deployer });
+          await vesting.methods.activate().send({ from: deployer });
           await expectRevert(async () => await setAmountForUser2(), Error.VestingAlreadyStarted);
         });
 
         describe("per user and global amounts are accurate", () => {
           it("no users", async () => {
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.zero;
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.zero;
           });
 
           it("single user", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            expect((await vesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
           });
 
           it("single user, amount updated to same amount as previously", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            expect((await vesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
           });
 
           it("multiple users", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(3_500)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(1_000)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_500));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(1_000));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(
+            await vesting.methods.setAmount(user1, await projectToken.amount(3_500)).send({ from: deployer });
+            await vesting.methods.setAmount(user2, await projectToken.amount(1_000)).send({ from: deployer });
+            expect((await vesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_500));
+            expect((await vesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(1_000));
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.eq(
               await (await projectToken.amount(3_500)).plus(await projectToken.amount(1_000))
             );
           });
 
           it("multiple users, amount reduced", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(10_000)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(10_000)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(3_000)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_000));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(10_000));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(13_000));
+            await vesting.methods.setAmount(user1, await projectToken.amount(10_000)).send({ from: deployer });
+            await vesting.methods.setAmount(user2, await projectToken.amount(10_000)).send({ from: deployer });
+            await vesting.methods.setAmount(user1, await projectToken.amount(3_000)).send({ from: deployer });
+            expect((await vesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(3_000));
+            expect((await vesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(10_000));
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(13_000));
           });
 
           it("multiple users, amount reduced to zero", async () => {
-            await uninsuredVesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-            await uninsuredVesting.methods.setAmount(user2, await projectToken.amount(0)).send({ from: deployer });
-            expect((await uninsuredVesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
-            expect((await uninsuredVesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(0));
-            expect(await uninsuredVesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(TOKENS_PER_USER));
+            await vesting.methods.setAmount(user1, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await vesting.methods.setAmount(user2, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+            await vesting.methods.setAmount(user2, await projectToken.amount(0)).send({ from: deployer });
+            expect((await vesting.methods.userVestings(user1).call()).amount).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+            expect((await vesting.methods.userVestings(user2).call()).amount).to.be.bignumber.eq(await projectToken.amount(0));
+            expect(await vesting.methods.totalAllocated().call()).to.be.bignumber.eq(await await projectToken.amount(TOKENS_PER_USER));
           });
         });
       });
@@ -274,7 +265,7 @@ describe("UninsuredVestingV1", () => {
   describe("activate", () => {
     it("fails if there isn't enough PROJECT_TOKEN allowance to cover total allocated", async () => {
       await setAmountForUser1();
-      await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), "ERC20: insufficient allowance");
+      await expectRevert(async () => vesting.methods.activate().send({ from: deployer }), "ERC20: insufficient allowance");
     });
 
     it("fails if there isn't enough PROJECT_TOKEN balance to cover total allocated", async () => {
@@ -282,58 +273,58 @@ describe("UninsuredVestingV1", () => {
       await approveProjectTokenToVesting();
       // Get rid of all balance
       await projectToken.methods.transfer(anyUser, await projectToken.amount(1e9)).send({ from: deployer });
-      await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), "ERC20: transfer amount exceeds balance");
+      await expectRevert(async () => vesting.methods.activate().send({ from: deployer }), "ERC20: transfer amount exceeds balance");
     });
 
     it("transfers PROJECT_TOKEN proportional to total allocated", async () => {
       await setAmountForUser1();
       await approveProjectTokenToVesting();
-      await uninsuredVesting.methods.activate().send({ from: deployer });
-      expect(await projectToken.methods.balanceOf(uninsuredVesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
+      await vesting.methods.activate().send({ from: deployer });
+      expect(await projectToken.methods.balanceOf(vesting.options.address).call()).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
     });
 
     it("does not transfer PROJECT_TOKEN if already funded sufficiently", async () => {
       await setAmountForUser1();
       await approveProjectTokenToVesting();
-      await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
-      const initialContractProjectTokenBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
-      await uninsuredVesting.methods.activate().send({ from: deployer });
-      const currentContractBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
+      await projectToken.methods.transfer(vesting.options.address, await projectToken.amount(TOKENS_PER_USER)).send({ from: deployer });
+      const initialContractProjectTokenBalance = await projectToken.methods.balanceOf(vesting.options.address).call();
+      await vesting.methods.activate().send({ from: deployer });
+      const currentContractBalance = await projectToken.methods.balanceOf(vesting.options.address).call();
       expect(initialContractProjectTokenBalance).to.be.bignumber.eq(currentContractBalance);
     });
 
     it("transfers PROJECT_TOKEN required to back FUNDING_TOKEN funding (partially pre-funded)", async () => {
       await setAmountForUser1();
       await approveProjectTokenToVesting();
-      await projectToken.methods.transfer(uninsuredVesting.options.address, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
-      await uninsuredVesting.methods.activate().send({ from: deployer });
-      const contractProjectTokenBalance = await projectToken.methods.balanceOf(uninsuredVesting.options.address).call();
+      await projectToken.methods.transfer(vesting.options.address, await projectToken.amount(TOKENS_PER_USER / 4)).send({ from: deployer });
+      await vesting.methods.activate().send({ from: deployer });
+      const contractProjectTokenBalance = await projectToken.methods.balanceOf(vesting.options.address).call();
       expect(contractProjectTokenBalance).to.be.bignumber.eq(await projectToken.amount(TOKENS_PER_USER));
     });
 
     it("fails if already activated", async () => {
       await setAmountForUser1();
       await approveProjectTokenToVesting();
-      await uninsuredVesting.methods.activate().send({ from: deployer });
-      await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), Error.VestingAlreadyStarted);
+      await vesting.methods.activate().send({ from: deployer });
+      await expectRevert(async () => vesting.methods.activate().send({ from: deployer }), Error.VestingAlreadyStarted);
     });
 
     it("fails if no allocations added", async () => {
-      await expectRevert(async () => uninsuredVesting.methods.activate().send({ from: deployer }), Error.NoAllocationsAdded);
+      await expectRevert(async () => vesting.methods.activate().send({ from: deployer }), Error.NoAllocationsAdded);
     });
 
     it("sets start time", async () => {
       await setAmountForUser1();
       await approveProjectTokenToVesting();
-      await uninsuredVesting.methods.activate().send({ from: deployer });
-      expect(await uninsuredVesting.methods.vestingStartTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
+      await vesting.methods.activate().send({ from: deployer });
+      expect(await vesting.methods.vestingStartTime().call()).to.be.bignumber.eq(await getCurrentTimestamp());
     });
   });
 
   describe("view functions", () => {
     it("returns 0 vested when not activated", async () => {
       await setAmountForUser1();
-      expect(await uninsuredVesting.methods.totalVestedFor(user1).call()).to.be.bignumber.eq(0);
+      expect(await vesting.methods.totalVestedFor(user1).call()).to.be.bignumber.eq(0);
     });
   });
 });


### PR DESCRIPTION
Closes #85 

[Refactor: renaming of variables to make contracts more generic](https://github.com/exciteddao/excited-contracts/pull/93/commits/a2e830ba9c742c5d1cd1bb3fa6bcba9ec93a50ea)
[Refactor: rename `UninsuredVesting` usages to `Vesting`](https://github.com/exciteddao/excited-contracts/pull/93/commits/9afeaa498b9467457013cf1cbbce1c94a009419e)

**Please note I have not yet renamed the file names and paths themselves to make it (a little) easier to reivew**